### PR TITLE
Make refreshBuckets public for direct update

### DIFF
--- a/src/pair.ts
+++ b/src/pair.ts
@@ -46,7 +46,7 @@ export abstract class PairXYeqK extends Pair {
 	private bucketA: BigNumber = new BigNumber(0)
 	private bucketB: BigNumber = new BigNumber(0)
 
-	protected refreshBuckets(fee: BigNumber, bucketA: BigNumber, bucketB: BigNumber) {
+	public refreshBuckets(fee: BigNumber, bucketA: BigNumber, bucketB: BigNumber) {
 		this.fee = fee
 		this.bucketA = bucketA
 		this.bucketB = bucketB


### PR DESCRIPTION
Can we please have refreshBucket be public so that I can directly refresh the pair data off of decoded pending transactions?

Flow is:
- read & decode pending transactions to DEX pairs / DEX routers
- directly update bucket based on predicted changes from executing the pending transactions
- predict routes based on pending transactions