### PR TITLE
Send optional min input amount data in extra data

### DIFF
--- a/contracts/swappa/PairAToken.sol
+++ b/contracts/swappa/PairAToken.sol
@@ -20,8 +20,9 @@ contract PairAToken is ISwappaPairV1 {
 		address to,
 		bytes calldata data
 	) external override {
-		(address providerAddr, uint8 inputType) = parseData(data);
+		(address providerAddr, uint8 inputType, uint minInputAmount) = parseData(data);
 		uint inputAmount = ERC20(input).balanceOf(address(this));
+		require(inputAmount >= minInputAmount, "PairATokenV2: insufficient input amount");
 		if (inputType == 1) {
 			// Redeem AToken.
 			IAToken(input).redeem(inputAmount);
@@ -46,12 +47,22 @@ contract PairAToken is ISwappaPairV1 {
 			"PairAToken: transfer failed!");
 	}
 
-	function parseData(bytes memory data) private pure returns (address providerAddr, uint8 inputType) {
-		require(data.length == 21, "PairAToken: invalid data!");
+	function parseData(bytes memory data) private pure returns (address providerAddr, uint8 inputType, uint minInputAmount) {
+		require(data.length == 21 || data.length == 21 + 32, "PairAToken: invalid data!");
 		inputType = uint8(data[20]);
     assembly {
-      providerAddr := mload(add(data, 20))
+      providerAddr := mload(add(data, 0x20))
     }
+		if (data.length == 21) {
+			minInputAmount = 0;
+		} else {
+			assembly {
+				// 0x20 is the first slot of array containing the length
+				// offset by 20 bytes for address and 1 byte for fee
+				// minimal input amount start 0x35
+				minInputAmount := mload(add(data, 0x35))
+			}
+		}
 	}
 
 	receive() external payable {}

--- a/contracts/swappa/PairATokenV2.sol
+++ b/contracts/swappa/PairATokenV2.sol
@@ -15,8 +15,9 @@ contract PairATokenV2 is ISwappaPairV1 {
 		address to,
 		bytes calldata data
 	) external override {
-		(address poolAddr, uint8 inputType) = parseData(data);
+		(address poolAddr, uint8 inputType, uint minInputAmount) = parseData(data);
 		uint inputAmount = ERC20(input).balanceOf(address(this));
+		require(inputAmount >= minInputAmount, "PairATokenV2: insufficient input amount");
 		if (inputType == 1) {
 			// AToken -> Underlying.
 			ILendingPoolV2(poolAddr).withdraw(output, inputAmount, to);
@@ -29,12 +30,22 @@ contract PairATokenV2 is ISwappaPairV1 {
 		}
 	}
 
-	function parseData(bytes memory data) private pure returns (address poolAddr, uint8 inputType) {
-		require(data.length == 21, "PairATokenV2: invalid data!");
+	function parseData(bytes memory data) private pure returns (address poolAddr, uint8 inputType, uint minInputAmount) {
+		require(data.length == 21 || data.length == 21 + 32, "PairATokenV2: invalid data!");
 		inputType = uint8(data[20]);
     assembly {
-      poolAddr := mload(add(data, 20))
+      poolAddr := mload(add(data, 0x20))
     }
+		if (data.length == 21) {
+			minInputAmount = 0;
+		} else {
+			assembly {
+				// 0x20 is the first slot of array containing the length
+				// offset by 20 bytes for address and 1 byte for fee
+				// minimal input amount start 0x35
+				minInputAmount := mload(add(data, 0x35))
+			}
+		}
 	}
 
 	receive() external payable {}

--- a/src/pair.ts
+++ b/src/pair.ts
@@ -31,11 +31,19 @@ export abstract class Pair {
 		swappaPairAddress: Address,
 	}>;
 	public abstract refresh(): Promise<void>;
-	public swapData(inputToken: Address): SwapData {
+	public swapData(inputToken: Address, inputAmount?: BigNumber): SwapData {
 		return {
 			addr: this.swappaPairAddress,
-			extra: this.swapExtraData(inputToken),
+			extra: this.swapExtraDataWithInputAmount(inputToken, inputAmount),
 		}
+	}
+	protected swapExtraDataWithInputAmount(inputToken: Address, inputAmount?: BigNumber): string {
+		const swapExtraData = this.swapExtraData(inputToken)
+		if (!inputAmount) {
+			return swapExtraData
+		}
+		const inputAmountData = inputAmount.integerValue().toString(16).padStart(64, "0")
+		return `${swapExtraData}${inputAmountData}`
 	}
 	protected abstract swapExtraData(inputToken: Address): string;
 	public abstract outputAmount(inputToken: Address, inputAmount: BigNumber): BigNumber;

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,8 @@ export interface Route {
 	path: Address[]
 	outputToken: Address
 	outputAmount: BigNumber
+	// the input amounts for each step of the path
+	pathInputAmounts: BigNumber[]
 }
 
 export interface RouterOpts {
@@ -29,6 +31,7 @@ export const findBestRoutesForFixedInputAmount = (
 				path: [inputToken],
 				outputToken: inputToken,
 				outputAmount: inputAmount,
+				pathInputAmounts: []
 			}
 		]
 	])
@@ -50,7 +53,8 @@ export const findBestRoutesForFixedInputAmount = (
 				if (pair.pairKey !== null && route.pairs.find((p) => p.pairKey === pair.pairKey)) {
 					continue // skip already used or conflicting pairs.
 				}
-				const outputTAmount = pair.outputAmount(route.outputToken, route.outputAmount)
+				const inputTAmount = route.outputAmount;
+				const outputTAmount = pair.outputAmount(route.outputToken, inputTAmount)
 				const maxOutputAmount = maxOutputAmounts.get(outputT) || new BigNumber(0)
 				if (maxOutputAmount.gte(outputTAmount)) {
 					continue // we have already explored better routes before.
@@ -59,6 +63,7 @@ export const findBestRoutesForFixedInputAmount = (
 				const routeT: Route = {
 					pairs: [...route.pairs, pair],
 					path: [...route.path, outputT],
+					pathInputAmounts: [...route.pathInputAmounts, inputTAmount],
 					outputToken: outputT,
 					outputAmount: outputTAmount,
 				}


### PR DESCRIPTION
Optionally include a uint256 at the end of `extra` to use as minimal input amount check.

If the bytes are there, decode it and use as part of input amount check.
If the bytes are not there, use default min input of 0.

This should add very negligible gas overhead.