### PR TITLE
Implement getOutputAmount() in all pair interface to pre-compute final output

### DIFF
--- a/contracts/interfaces/stableswap/ISwap.sol
+++ b/contracts/interfaces/stableswap/ISwap.sol
@@ -15,4 +15,10 @@ interface ISwap {
 		uint256 minDy,
 		uint256 deadline
 	) external returns (uint256);
+
+	function calculateSwap(
+        uint8 tokenIndexFrom,
+        uint8 tokenIndexTo,
+        uint256 dx
+    ) external view returns (uint256);
 }

--- a/contracts/interfaces/stableswap/ISwap.sol
+++ b/contracts/interfaces/stableswap/ISwap.sol
@@ -17,8 +17,8 @@ interface ISwap {
 	) external returns (uint256);
 
 	function calculateSwap(
-        uint8 tokenIndexFrom,
-        uint8 tokenIndexTo,
-        uint256 dx
-    ) external view returns (uint256);
+		uint8 tokenIndexFrom,
+		uint8 tokenIndexTo,
+		uint256 dx
+	) external view returns (uint256);
 }

--- a/contracts/swappa/ISwappaPairV1.sol
+++ b/contracts/swappa/ISwappaPairV1.sol
@@ -8,4 +8,10 @@ interface ISwappaPairV1 {
 		address to,
 		bytes calldata data
 	) external;
+
+	function calculateAmountOut(
+		address input,
+		uint amountIn,
+		bytes calldata data
+	) external view returns (uint amountOut);
 }

--- a/contracts/swappa/ISwappaPairV1.sol
+++ b/contracts/swappa/ISwappaPairV1.sol
@@ -9,6 +9,8 @@ interface ISwappaPairV1 {
 		bytes calldata data
 	) external;
 
+	// Get the output amount in output token for a given amountIn of the input token, with the encoded extra data.
+	// Output amount is undefined if input token is invalid for the swap pair.
 	function getOutputAmount(
 		address input,
 		uint amountIn,

--- a/contracts/swappa/ISwappaPairV1.sol
+++ b/contracts/swappa/ISwappaPairV1.sol
@@ -9,7 +9,7 @@ interface ISwappaPairV1 {
 		bytes calldata data
 	) external;
 
-	function calculateAmountOut(
+	function getOutputAmount(
 		address input,
 		uint amountIn,
 		bytes calldata data

--- a/contracts/swappa/PairAToken.sol
+++ b/contracts/swappa/PairAToken.sol
@@ -54,7 +54,7 @@ contract PairAToken is ISwappaPairV1 {
     }
 	}
 
-	function calculateAmountOut(
+	function getOutputAmount(
 		address input,
 		uint amountIn,
 		bytes calldata data

--- a/contracts/swappa/PairAToken.sol
+++ b/contracts/swappa/PairAToken.sol
@@ -54,5 +54,13 @@ contract PairAToken is ISwappaPairV1 {
     }
 	}
 
+	function calculateAmountOut(
+		address input,
+		uint amountIn,
+		bytes calldata data
+	) external view override returns (uint amountOut) {
+		return amountIn;
+	}
+
 	receive() external payable {}
 }

--- a/contracts/swappa/PairATokenV2.sol
+++ b/contracts/swappa/PairATokenV2.sol
@@ -37,7 +37,7 @@ contract PairATokenV2 is ISwappaPairV1 {
     }
 	}
 
-	function calculateAmountOut(
+	function getOutputAmount(
 		address input,
 		uint amountIn,
 		bytes calldata data

--- a/contracts/swappa/PairATokenV2.sol
+++ b/contracts/swappa/PairATokenV2.sol
@@ -37,5 +37,13 @@ contract PairATokenV2 is ISwappaPairV1 {
     }
 	}
 
+	function calculateAmountOut(
+		address input,
+		uint amountIn,
+		bytes calldata data
+	) external view override returns (uint amountOut) {
+		return amountIn;
+	}
+
 	receive() external payable {}
 }

--- a/contracts/swappa/PairMento.sol
+++ b/contracts/swappa/PairMento.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "./ISwappaPairV1.sol";
 
 interface IExchange {
-	function stable() external returns (address);
+	function stable() external view returns (address);
 	function sell(uint256 sellAmount, uint256 minBuyAmount, bool sellGold) external returns (uint256);
 	function getBuyTokenAmount(uint256 sellAmount, bool sellGold) external view returns (uint256);
 }

--- a/contracts/swappa/PairMento.sol
+++ b/contracts/swappa/PairMento.sol
@@ -40,7 +40,7 @@ contract PairMento is ISwappaPairV1 {
     }
 	}
 
-	function calculateAmountOut(
+	function getOutputAmount(
 		address input,
 		uint amountIn,
 		bytes calldata data

--- a/contracts/swappa/PairMento.sol
+++ b/contracts/swappa/PairMento.sol
@@ -8,6 +8,7 @@ import "./ISwappaPairV1.sol";
 interface IExchange {
 	function stable() external returns (address);
 	function sell(uint256 sellAmount, uint256 minBuyAmount, bool sellGold) external returns (uint256);
+	function getBuyTokenAmount(uint256 sellAmount, bool sellGold) external view returns (uint256);
 }
 
 contract PairMento is ISwappaPairV1 {
@@ -37,6 +38,17 @@ contract PairMento is ISwappaPairV1 {
     assembly {
       exchangeAddr := mload(add(data, 20))
     }
+	}
+
+	function calculateAmountOut(
+		address input,
+		uint amountIn,
+		bytes calldata data
+	) external view override returns (uint amountOut) {
+		address exchangeAddr = parseData(data);
+		IExchange exchange = IExchange(exchangeAddr);
+		bool sellGold = (exchange.stable() != input);
+		return exchange.getBuyTokenAmount(amountIn, sellGold);
 	}
 
 	receive() external payable {}

--- a/contracts/swappa/PairSavingsCELO.sol
+++ b/contracts/swappa/PairSavingsCELO.sol
@@ -41,12 +41,12 @@ contract PairSavingsCELO is ISwappaPairV1 {
 		bytes calldata data
 	) external view override returns (uint amountOut) {
 		address savingsCELOAddr = parseData(data);
-		if (input == 0x2879BFD5e7c4EF331384E908aaA3Bd3014b703fA) {
-			// Savings CELO
-			return ISavingsCELO(savingsCELOAddr).savingsToCELO(amountIn);
-		} else if (input == 0x471EcE3750Da237f93B8E339c536989b8978a438) {
+		if (input == 0x471EcE3750Da237f93B8E339c536989b8978a438) {
 			// CELO
 			return ISavingsCELO(savingsCELOAddr).celoToSavings(amountIn);
+		} else if (input == 0x2879BFD5e7c4EF331384E908aaA3Bd3014b703fA) {
+			// Savings CELO
+			return ISavingsCELO(savingsCELOAddr).savingsToCELO(amountIn);
 		} else {
 			return 0;
 		}

--- a/contracts/swappa/PairSavingsCELO.sol
+++ b/contracts/swappa/PairSavingsCELO.sol
@@ -34,7 +34,7 @@ contract PairSavingsCELO is ISwappaPairV1 {
     }
 	}
 
-	function calculateAmountOut(
+	function getOutputAmount(
 		address input,
 		uint amountIn,
 		bytes calldata data

--- a/contracts/swappa/PairSavingsCELO.sol
+++ b/contracts/swappa/PairSavingsCELO.sol
@@ -8,6 +8,7 @@ import "./ISwappaPairV1.sol";
 interface ISavingsCELO {
 	function deposit() external payable returns (uint256 toMint);
 	function celoToSavings(uint256 celoAmount) external view returns (uint256);
+	function savingsToCELO(uint256 savingsAmount) external view returns (uint256);
 }
 
 contract PairSavingsCELO is ISwappaPairV1 {
@@ -40,7 +41,15 @@ contract PairSavingsCELO is ISwappaPairV1 {
 		bytes calldata data
 	) external view override returns (uint amountOut) {
 		address savingsCELOAddr = parseData(data);
-		return ISavingsCELO(savingsCELOAddr).celoToSavings(amountIn);
+		if (input == 0x2879BFD5e7c4EF331384E908aaA3Bd3014b703fA) {
+			// Savings CELO
+			return ISavingsCELO(savingsCELOAddr).savingsToCELO(amountIn);
+		} else if (input == 0x471EcE3750Da237f93B8E339c536989b8978a438) {
+			// CELO
+			return ISavingsCELO(savingsCELOAddr).celoToSavings(amountIn);
+		} else {
+			return 0;
+		}
 	}
 
 	receive() external payable {}

--- a/contracts/swappa/PairSavingsCELO.sol
+++ b/contracts/swappa/PairSavingsCELO.sol
@@ -7,6 +7,7 @@ import "./ISwappaPairV1.sol";
 
 interface ISavingsCELO {
 	function deposit() external payable returns (uint256 toMint);
+	function celoToSavings(uint256 celoAmount) external view returns (uint256);
 }
 
 contract PairSavingsCELO is ISwappaPairV1 {
@@ -31,6 +32,15 @@ contract PairSavingsCELO is ISwappaPairV1 {
     assembly {
       savingsCELOAddr := mload(add(data, 20))
     }
+	}
+
+	function calculateAmountOut(
+		address input,
+		uint amountIn,
+		bytes calldata data
+	) external view override returns (uint amountOut) {
+		address savingsCELOAddr = parseData(data);
+		return ISavingsCELO(savingsCELOAddr).celoToSavings(amountIn);
 	}
 
 	receive() external payable {}

--- a/contracts/swappa/PairStableSwap.sol
+++ b/contracts/swappa/PairStableSwap.sol
@@ -39,5 +39,19 @@ contract PairStableSwap is ISwappaPairV1 {
     }
 	}
 
+	function calculateAmountOut(
+		address input,
+		uint amountIn,
+		bytes calldata data
+	) external view override returns (uint amountOut) {
+		address swapPoolAddr = parseData(data);
+		ISwap swapPool = ISwap(swapPoolAddr);
+		if (swapPool.getToken(0) == input) {
+			return swapPool.calculateSwap(0, 1, amountIn);
+		} else {
+			return swapPool.calculateSwap(1, 0, amountIn);
+		}
+	}
+
 	receive() external payable {}
 }

--- a/contracts/swappa/PairStableSwap.sol
+++ b/contracts/swappa/PairStableSwap.sol
@@ -39,7 +39,7 @@ contract PairStableSwap is ISwappaPairV1 {
     }
 	}
 
-	function calculateAmountOut(
+	function getOutputAmount(
 		address input,
 		uint amountIn,
 		bytes calldata data

--- a/contracts/swappa/PairUniswapV2.sol
+++ b/contracts/swappa/PairUniswapV2.sol
@@ -39,7 +39,7 @@ contract PairUniswapV2 is ISwappaPairV1 {
     }
 	}
 
-	function calculateAmountOut(
+	function getOutputAmount(
 		address input,
 		uint amountIn,
 		bytes calldata data

--- a/contracts/swappa/PairUniswapV2.sol
+++ b/contracts/swappa/PairUniswapV2.sol
@@ -39,12 +39,24 @@ contract PairUniswapV2 is ISwappaPairV1 {
     }
 	}
 
+	function calculateAmountOut(
+		address input,
+		uint amountIn,
+		bytes calldata data
+	) external view override returns (uint amountOut) {
+		(address pairAddr, uint feeK) = parseData(data);
+		IUniswapV2Pair pair = IUniswapV2Pair(pairAddr);
+		(uint reserve0, uint reserve1,) = pair.getReserves();
+		(uint reserveIn, uint reserveOut) = pair.token0() == input ? (reserve0, reserve1) : (reserve1, reserve0);
+		return getAmountOut(amountIn, reserveIn, reserveOut, feeK);
+	}
+
 	function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut, uint feeK) internal pure returns (uint amountOut) {
 		uint amountInWithFee = amountIn.mul(feeK);
 		uint numerator = amountInWithFee.mul(reserveOut);
 		uint denominator = reserveIn.mul(1000).add(amountInWithFee);
 		amountOut = numerator / denominator;
-  }
+  	}
 
 	receive() external payable {}
 }

--- a/contracts/swappa/SwappaRouterV1.sol
+++ b/contracts/swappa/SwappaRouterV1.sol
@@ -42,7 +42,7 @@ contract SwappaRouterV1 {
 			for (uint i; i < pairs.length; i++) {
 				address pairInput = path[i];
 				bytes memory data = extras[i];
-				dryrunAmount = ISwappaPairV1(pairs[i]).calculateAmountOut(pairInput, dryrunAmount, data);
+				dryrunAmount = ISwappaPairV1(pairs[i]).getOutputAmount(pairInput, dryrunAmount, data);
 			}
 			require(
 				dryrunAmount >= minOutputAmount, "SwappaRouter: Insufficient dryrun output amount!");

--- a/contracts/swappa/SwappaRouterV1.sol
+++ b/contracts/swappa/SwappaRouterV1.sol
@@ -42,10 +42,12 @@ contract SwappaRouterV1 {
 			for (uint i; i < pairs.length; i++) {
 				address pairInput = path[i];
 				bytes memory data = extras[i];
-				dryrunAmount = ISwappaPairV1(pairs[i]).getOutputAmount(pairInput, dryrunAmount, data);
+				dryrunAmount =
+					ISwappaPairV1(pairs[i]).getOutputAmount(pairInput, dryrunAmount, data);
 			}
 			require(
-				dryrunAmount >= minOutputAmount, "SwappaRouter: Insufficient dryrun output amount!");
+				dryrunAmount >= minOutputAmount,
+				"SwappaRouter: Insufficient dryrun output amount!");
 		}
 
 		for (uint i; i < pairs.length; i++) {

--- a/contracts/swappa/SwappaRouterV1.sol
+++ b/contracts/swappa/SwappaRouterV1.sol
@@ -20,7 +20,7 @@ contract SwappaRouterV1 {
 		_;
 	}
 
-	function dryrunSwap(
+	function getOutputAmount(
 		address[] calldata path,
 		address[] calldata pairs,
 		bytes[] calldata extras,
@@ -51,13 +51,6 @@ contract SwappaRouterV1 {
 		require(
 			ERC20(path[0]).transferFrom(msg.sender, pairs[0], inputAmount),
 			"SwappaRouter: Initial transferFrom failed!");
-		{
-			// Perform dryrun of swaps to verify the final output
-			uint dryrunAmount = this.dryrunSwap(path, pairs, extras, inputAmount);
-			require(
-				dryrunAmount >= minOutputAmount,
-				"SwappaRouter: Insufficient dryrun output amount!");
-		}
 
 		for (uint i; i < pairs.length; i++) {
 			(address pairInput, address pairOutput) = (path[i], path[i + 1]);

--- a/contracts/swappa/SwappaRouterV1.sol
+++ b/contracts/swappa/SwappaRouterV1.sol
@@ -51,7 +51,6 @@ contract SwappaRouterV1 {
 		require(
 			ERC20(path[0]).transferFrom(msg.sender, pairs[0], inputAmount),
 			"SwappaRouter: Initial transferFrom failed!");
-
 		for (uint i; i < pairs.length; i++) {
 			(address pairInput, address pairOutput) = (path[i], path[i + 1]);
 			address next = i < pairs.length - 1 ? pairs[i+1] : address(this);

--- a/contracts/swappa/SwappaRouterV1.sol
+++ b/contracts/swappa/SwappaRouterV1.sol
@@ -36,6 +36,18 @@ contract SwappaRouterV1 {
 		require(
 			ERC20(path[0]).transferFrom(msg.sender, pairs[0], inputAmount),
 			"SwappaRouter: Initial transferFrom failed!");
+		{
+			// Perform dryrun of swaps to verify the final output
+			uint dryrunAmount = inputAmount;
+			for (uint i; i < pairs.length; i++) {
+				address pairInput = path[i];
+				bytes memory data = extras[i];
+				dryrunAmount = ISwappaPairV1(pairs[i]).calculateAmountOut(pairInput, dryrunAmount, data);
+			}
+			require(
+				dryrunAmount >= minOutputAmount, "SwappaRouter: Insufficient dryrun output amount!");
+		}
+
 		for (uint i; i < pairs.length; i++) {
 			(address pairInput, address pairOutput) = (path[i], path[i + 1]);
 			address next = i < pairs.length - 1 ? pairs[i+1] : address(this);

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,6 +4,7 @@ import { Address, Pair } from "./pair"
 export interface Route {
 	pairs: Pair[]
 	path: Address[]
+	pathAmounts: BigNumber[]
 	outputToken: Address
 	outputAmount: BigNumber
 }
@@ -27,6 +28,7 @@ export const findBestRoutesForFixedInputAmount = (
 			inputToken, {
 				pairs: [],
 				path: [inputToken],
+				pathAmounts: [inputAmount],
 				outputToken: inputToken,
 				outputAmount: inputAmount,
 			}
@@ -59,6 +61,7 @@ export const findBestRoutesForFixedInputAmount = (
 				const routeT: Route = {
 					pairs: [...route.pairs, pair],
 					path: [...route.path, outputT],
+					pathAmounts: [...route.pathAmounts, outputTAmount],
 					outputToken: outputT,
 					outputAmount: outputTAmount,
 				}


### PR DESCRIPTION
Implement `getOutputAmount()` in all pair types to compute the output amount given an input token & input amount.

Implement `getOutputAmount()` inside swappa router to compute the final output of a given swap path