### PR TITLE
Name the registry instances, and track which registry provided which pair

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -75,7 +75,7 @@ async function main() {
 	for (const registry of registries) {
 		for (const pair of manager.getPairsByRegistry(registry)) {
 			console.info(
-				`${registry.getName()}:` +
+				`${registry.getName().padEnd(12)}` +
 				`${(pair as any).constructor?.name}:${pair.pairKey}: ` +
 				`${tokenByAddrOrSymbol(pair.tokenA).symbol} / ${tokenByAddrOrSymbol(pair.tokenB).symbol}`)
 		}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -72,11 +72,10 @@ async function main() {
 	console.info(`Finding & initializing pairs...`)
 	const pairs = await manager.reinitializePairs(tokenWhitelist)
 	console.info(`Pairs (${pairs.length}):`)
-
 	for (const registry of registries) {
-		for (const pair of manager.lookupPairs(registry)) {
+		for (const pair of manager.getPairsByRegistry(registry)) {
 			console.info(
-				`${(registry as any).constructor?.name}:` +
+				`${registry.getName()}:` +
 				`${(pair as any).constructor?.name}:${pair.pairKey}: ` +
 				`${tokenByAddrOrSymbol(pair.tokenA).symbol} / ${tokenByAddrOrSymbol(pair.tokenB).symbol}`)
 		}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -36,14 +36,14 @@ process.on('unhandledRejection', (reason: any, _promise: any) => {
 })
 
 const registriesByName: {[name: string]: (kit: ContractKit) => Registry} = {
-	"mento":		(kit: ContractKit) =>	new RegistryMento(kit),
-	"ubeswap":		mainnetRegistryUbeswap,
-	"sushiswap":	mainnetRegistrySushiswap,
-	"mobius":		mainnetRegistryMobius,
-	"moola":		mainnetRegistryMoola,
-	"moola-v2":		mainnetRegistryMoolaV2,
-	"savingscelo":	mainnetRegistrySavingsCELO,
-	"celodex":		mainnetRegistryCeloDex,
+	"mento":       (kit: ContractKit) => new RegistryMento(kit),
+	"ubeswap":     mainnetRegistryUbeswap,
+	"sushiswap":   mainnetRegistrySushiswap,
+	"mobius":      mainnetRegistryMobius,
+	"moola":       mainnetRegistryMoola,
+	"moola-v2":    mainnetRegistryMoolaV2,
+	"savingscelo": mainnetRegistrySavingsCELO,
+	"celodex":     mainnetRegistryCeloDex,
 }
 
 function tokenByAddrOrSymbol(addressOrSymbol: string) {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -72,10 +72,14 @@ async function main() {
 	console.info(`Finding & initializing pairs...`)
 	const pairs = await manager.reinitializePairs(tokenWhitelist)
 	console.info(`Pairs (${pairs.length}):`)
-	for (const pair of pairs) {
-		console.info(
-			`${(pair as any).constructor?.name}:${pair.pairKey}: ` +
-			`${tokenByAddrOrSymbol(pair.tokenA).symbol} / ${tokenByAddrOrSymbol(pair.tokenB).symbol}`)
+
+	for (const registry of registries) {
+		for (const pair of manager.lookupPairs(registry)) {
+			console.info(
+				`${(registry as any).constructor?.name}:` +
+				`${(pair as any).constructor?.name}:${pair.pairKey}: ` +
+				`${tokenByAddrOrSymbol(pair.tokenA).symbol} / ${tokenByAddrOrSymbol(pair.tokenB).symbol}`)
+		}
 	}
 
 	console.info(`--------------------------------------------------------------------------------`)

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -73,7 +73,7 @@ async function main() {
 	const pairs = await manager.reinitializePairs(tokenWhitelist)
 	console.info(`Pairs (${pairs.length}):`)
 	for (const registry of registries) {
-		for (const pair of manager.getPairsByRegistry(registry)) {
+		for (const pair of manager.getPairsByRegistry(registry.getName())) {
 			console.info(
 				`${registry.getName().padEnd(12)}` +
 				`${(pair as any).constructor?.name}:${pair.pairKey}: ` +

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -36,14 +36,14 @@ process.on('unhandledRejection', (reason: any, _promise: any) => {
 })
 
 const registriesByName: {[name: string]: (kit: ContractKit) => Registry} = {
-	"mento": (kit: ContractKit) =>	new RegistryMento(kit),
-	"ubeswap":	mainnetRegistryUbeswap,
+	"mento":		(kit: ContractKit) =>	new RegistryMento(kit),
+	"ubeswap":		mainnetRegistryUbeswap,
 	"sushiswap":	mainnetRegistrySushiswap,
-	"mobius":	mainnetRegistryMobius,
-	"moola":	mainnetRegistryMoola,
-	"moola-v2":	mainnetRegistryMoolaV2,
+	"mobius":		mainnetRegistryMobius,
+	"moola":		mainnetRegistryMoola,
+	"moola-v2":		mainnetRegistryMoolaV2,
 	"savingscelo":	mainnetRegistrySavingsCELO,
-	"celodex":	mainnetRegistryCeloDex,
+	"celodex":		mainnetRegistryCeloDex,
 }
 
 function tokenByAddrOrSymbol(addressOrSymbol: string) {

--- a/src/registries/aave-v2.ts
+++ b/src/registries/aave-v2.ts
@@ -6,11 +6,13 @@ import { ILendingPoolAddressesProviderV2, ABI as ILendingPoolAddressesProviderV2
 import { Address } from "../pair"
 import { initPairsAndFilterByWhitelist } from "../utils"
 import { PairATokenV2 } from "../pairs/atoken-v2"
+import { Registry } from "../registry"
 
-export class RegistryAaveV2 {
+export class RegistryAaveV2 extends Registry {
 	private provider: ILendingPoolAddressesProviderV2
 
-	constructor(private kit: ContractKit, lendingPoolAddrProviderAddr: string) {
+	constructor(private kit: ContractKit, lendingPoolAddrProviderAddr: string, name?: string) {
+		super(name || lendingPoolAddrProviderAddr)
 		this.provider = new kit.web3.eth.Contract(ILendingPoolAddressesProviderV2ABI, lendingPoolAddrProviderAddr)
 	}
 

--- a/src/registries/aave-v2.ts
+++ b/src/registries/aave-v2.ts
@@ -11,8 +11,8 @@ import { Registry } from "../registry"
 export class RegistryAaveV2 extends Registry {
 	private provider: ILendingPoolAddressesProviderV2
 
-	constructor(private kit: ContractKit, lendingPoolAddrProviderAddr: string, name?: string) {
-		super(name || lendingPoolAddrProviderAddr)
+	constructor(name: string, private kit: ContractKit, lendingPoolAddrProviderAddr: string) {
+		super(name)
 		this.provider = new kit.web3.eth.Contract(ILendingPoolAddressesProviderV2ABI, lendingPoolAddrProviderAddr)
 	}
 

--- a/src/registries/aave.ts
+++ b/src/registries/aave.ts
@@ -10,8 +10,8 @@ import { initPairsAndFilterByWhitelist } from "../utils"
 export class RegistryAave extends Registry {
 	private lendingPoolAddrProvider: ILendingPoolAddressesProvider
 
-	constructor(private kit: ContractKit, lendingPoolAddrProviderAddr: string, name?: string) {
-		super(name || lendingPoolAddrProviderAddr)
+	constructor(name: string, private kit: ContractKit, lendingPoolAddrProviderAddr: string) {
+		super(name)
 		this.lendingPoolAddrProvider = new kit.web3.eth.Contract(
 			LendingPoolAddressProviderABI, lendingPoolAddrProviderAddr) as unknown as ILendingPoolAddressesProvider
 	}

--- a/src/registries/aave.ts
+++ b/src/registries/aave.ts
@@ -4,12 +4,14 @@ import { ILendingPool, ABI as LendingPoolABI } from "../../types/web3-v1-contrac
 import { ILendingPoolAddressesProvider, ABI as LendingPoolAddressProviderABI } from "../../types/web3-v1-contracts/ILendingPoolAddressesProvider"
 import { Address } from "../pair"
 import { PairAToken, ReserveCELO } from "../pairs/atoken"
+import { Registry } from "../registry"
 import { initPairsAndFilterByWhitelist } from "../utils"
 
-export class RegistryAave {
+export class RegistryAave extends Registry {
 	private lendingPoolAddrProvider: ILendingPoolAddressesProvider
 
-	constructor(private kit: ContractKit, lendingPoolAddrProviderAddr: string) {
+	constructor(private kit: ContractKit, lendingPoolAddrProviderAddr: string, name?: string) {
+		super(name || lendingPoolAddrProviderAddr)
 		this.lendingPoolAddrProvider = new kit.web3.eth.Contract(
 			LendingPoolAddressProviderABI, lendingPoolAddrProviderAddr) as unknown as ILendingPoolAddressesProvider
 	}

--- a/src/registries/mento.ts
+++ b/src/registries/mento.ts
@@ -3,10 +3,13 @@ import { concurrentMap } from '@celo/utils/lib/async'
 
 import { Address } from "../pair"
 import { PairMento } from "../pairs/mento"
+import { Registry } from "../registry"
 import { initPairsAndFilterByWhitelist } from "../utils"
 
-export class RegistryMento {
-	constructor(private kit: ContractKit) {}
+export class RegistryMento extends Registry{
+	constructor(private kit: ContractKit) {
+		super("Mento")
+	}
 
 	findPairs = async (tokenWhitelist: Address[]) => {
 		const cSTBs = await concurrentMap(

--- a/src/registries/mento.ts
+++ b/src/registries/mento.ts
@@ -8,7 +8,7 @@ import { initPairsAndFilterByWhitelist } from "../utils"
 
 export class RegistryMento extends Registry{
 	constructor(private kit: ContractKit) {
-		super("Mento")
+		super("mento")
 	}
 
 	findPairs = async (tokenWhitelist: Address[]) => {

--- a/src/registries/static.ts
+++ b/src/registries/static.ts
@@ -3,7 +3,7 @@ import { Registry } from "../registry"
 import { initPairsAndFilterByWhitelist } from "../utils"
 
 export class RegistryStatic extends Registry{
-	constructor(private pairsAll: Pair[], name: string) {
+	constructor(name: string, private pairsAll: Pair[]) {
 		super(name)
 	}
 

--- a/src/registries/static.ts
+++ b/src/registries/static.ts
@@ -1,8 +1,11 @@
 import { Address, Pair } from "../pair"
+import { Registry } from "../registry"
 import { initPairsAndFilterByWhitelist } from "../utils"
 
-export class RegistryStatic {
-	constructor(private pairsAll: Pair[]) {}
+export class RegistryStatic extends Registry{
+	constructor(private pairsAll: Pair[], name: string) {
+		super(name)
+	}
 
 	findPairs = async (tokenWhitelist: Address[]) => {
 		return initPairsAndFilterByWhitelist(this.pairsAll, tokenWhitelist)

--- a/src/registries/uniswapv2.ts
+++ b/src/registries/uniswapv2.ts
@@ -14,13 +14,13 @@ export class RegistryUniswapV2 extends Registry {
 	constructor(
 		private kit: ContractKit,
 		factoryAddr: Address,
+		name: string,
 		private opts?: {
 			fixedFee?: BigNumber,
 			fetchUsingAllPairs?: boolean,
 		},
-		name?: string,
 	) {
-		super(name || factoryAddr)
+		super(name)
 		this.factory = new kit.web3.eth.Contract(FactoryABI, factoryAddr) as unknown as IUniswapV2Factory
 	}
 

--- a/src/registries/uniswapv2.ts
+++ b/src/registries/uniswapv2.ts
@@ -12,9 +12,9 @@ export class RegistryUniswapV2 extends Registry {
 	private factory: IUniswapV2Factory
 
 	constructor(
+		name: string,
 		private kit: ContractKit,
 		factoryAddr: Address,
-		name: string,
 		private opts?: {
 			fixedFee?: BigNumber,
 			fetchUsingAllPairs?: boolean,

--- a/src/registries/uniswapv2.ts
+++ b/src/registries/uniswapv2.ts
@@ -5,9 +5,10 @@ import { concurrentMap } from '@celo/utils/lib/async'
 import { IUniswapV2Factory, ABI as FactoryABI } from "../../types/web3-v1-contracts/IUniswapV2Factory";
 import { Address, Pair } from "../pair";
 import { PairUniswapV2 } from "../pairs/uniswapv2";
+import { Registry } from "../registry";
 import { initPairsAndFilterByWhitelist } from "../utils";
 
-export class RegistryUniswapV2 {
+export class RegistryUniswapV2 extends Registry {
 	private factory: IUniswapV2Factory
 
 	constructor(
@@ -17,7 +18,9 @@ export class RegistryUniswapV2 {
 			fixedFee?: BigNumber,
 			fetchUsingAllPairs?: boolean,
 		},
+		name?: string,
 	) {
+		super(name || factoryAddr)
 		this.factory = new kit.web3.eth.Contract(FactoryABI, factoryAddr) as unknown as IUniswapV2Factory
 	}
 

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -12,9 +12,9 @@ import { RegistryUniswapV2 } from "./registries/uniswapv2"
 export const mainnetRegistryMoola =
 	(kit: ContractKit) => new RegistryAave(kit, "0x7AAaD5a5fa74Aec83b74C2a098FBC86E17Ce4aEA", "Moola")
 export const mainnetRegistryUbeswap =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x62d5b84bE28a183aBB507E125B384122D2C25fAE", undefined, "Ubeswap")
+	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x62d5b84bE28a183aBB507E125B384122D2C25fAE", "Ubeswap")
 export const mainnetRegistrySushiswap =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4", undefined, "Sushiswap")
+	(kit: ContractKit) => new RegistryUniswapV2(kit, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4", "Sushiswap")
 export const mainnetRegistryMobius =
 	(kit: ContractKit) => new RegistryStatic([
 		// Source: https://github.com/mobiusAMM/mobiusV1
@@ -43,10 +43,10 @@ export const mainnetRegistrySavingsCELO =
 export const mainnetRegistryMoolaV2 =
 	(kit: ContractKit) => new RegistryAaveV2(kit, "0xD1088091A174d33412a968Fa34Cb67131188B332", "MoolaV2")
 export const mainnetRegistryCeloDex =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x31bD38d982ccDf3C2D95aF45a3456d319f0Ee1b6", {
+	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x31bD38d982ccDf3C2D95aF45a3456d319f0Ee1b6", "CeloDex", {
 		fixedFee: new BigNumber(0.997), // TODO(zviadm): Figure out actual fee for CeloDex pairs.
 		fetchUsingAllPairs: true,
-	}, "CeloDex")
+	})
 
 // mainnetRegistriesWhitelist contains list of more established protocols with
 // overall higher TVL.

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -10,13 +10,13 @@ import { RegistryStatic } from "./registries/static"
 import { RegistryUniswapV2 } from "./registries/uniswapv2"
 
 export const mainnetRegistryMoola =
-	(kit: ContractKit) => new RegistryAave(kit, "0x7AAaD5a5fa74Aec83b74C2a098FBC86E17Ce4aEA", "Moola")
+	(kit: ContractKit) => new RegistryAave("moola", kit, "0x7AAaD5a5fa74Aec83b74C2a098FBC86E17Ce4aEA")
 export const mainnetRegistryUbeswap =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x62d5b84bE28a183aBB507E125B384122D2C25fAE", "Ubeswap")
+	(kit: ContractKit) => new RegistryUniswapV2("ubeswap", kit, "0x62d5b84bE28a183aBB507E125B384122D2C25fAE")
 export const mainnetRegistrySushiswap =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4", "Sushiswap")
+	(kit: ContractKit) => new RegistryUniswapV2("sushiswap", kit, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
 export const mainnetRegistryMobius =
-	(kit: ContractKit) => new RegistryStatic([
+	(kit: ContractKit) => new RegistryStatic("mobius", [
 		// Source: https://github.com/mobiusAMM/mobiusV1
 		new PairStableSwap(kit, "0x0ff04189Ef135b6541E56f7C638489De92E9c778"), // cUSD <-> bUSDC
 		new PairStableSwap(kit, "0xdBF27fD2a702Cc02ac7aCF0aea376db780D53247"), // cUSD <-> cUSDT
@@ -35,15 +35,15 @@ export const mainnetRegistryMobius =
 		new PairStableSwap(kit, "0x74ef28D635c6C5800DD3Cd62d4c4f8752DaACB09"), // cETH <-> WETHv2
 		new PairStableSwap(kit, "0xaEFc4e8cF655a182E8346B24c8AbcE45616eE0d2"), // cBTC <-> WBTCv2
 		new PairStableSwap(kit, "0xcCe0d62Ce14FB3e4363Eb92Db37Ff3630836c252"), // cUSD <-> pUSDCv2
-	], "Mobius")
+	])
 export const mainnetRegistrySavingsCELO =
-	(kit: ContractKit) =>  new RegistryStatic([
+	(kit: ContractKit) =>  new RegistryStatic("savingscelo", [
 		new PairSavingsCELO(kit, SavingsCELOAddressMainnet),
-	], "SavingsCELO")
+	])
 export const mainnetRegistryMoolaV2 =
-	(kit: ContractKit) => new RegistryAaveV2(kit, "0xD1088091A174d33412a968Fa34Cb67131188B332", "MoolaV2")
+	(kit: ContractKit) => new RegistryAaveV2("moola-v2", kit, "0xD1088091A174d33412a968Fa34Cb67131188B332")
 export const mainnetRegistryCeloDex =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x31bD38d982ccDf3C2D95aF45a3456d319f0Ee1b6", "CeloDex", {
+	(kit: ContractKit) => new RegistryUniswapV2("celodex", kit, "0x31bD38d982ccDf3C2D95aF45a3456d319f0Ee1b6", {
 		fixedFee: new BigNumber(0.997), // TODO(zviadm): Figure out actual fee for CeloDex pairs.
 		fetchUsingAllPairs: true,
 	})

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -10,11 +10,11 @@ import { RegistryStatic } from "./registries/static"
 import { RegistryUniswapV2 } from "./registries/uniswapv2"
 
 export const mainnetRegistryMoola =
-	(kit: ContractKit) => new RegistryAave(kit, "0x7AAaD5a5fa74Aec83b74C2a098FBC86E17Ce4aEA")
+	(kit: ContractKit) => new RegistryAave(kit, "0x7AAaD5a5fa74Aec83b74C2a098FBC86E17Ce4aEA", "Moola")
 export const mainnetRegistryUbeswap =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x62d5b84bE28a183aBB507E125B384122D2C25fAE")
+	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x62d5b84bE28a183aBB507E125B384122D2C25fAE", undefined, "Ubeswap")
 export const mainnetRegistrySushiswap =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
+	(kit: ContractKit) => new RegistryUniswapV2(kit, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4", undefined, "Sushiswap")
 export const mainnetRegistryMobius =
 	(kit: ContractKit) => new RegistryStatic([
 		// Source: https://github.com/mobiusAMM/mobiusV1
@@ -35,18 +35,18 @@ export const mainnetRegistryMobius =
 		new PairStableSwap(kit, "0x74ef28D635c6C5800DD3Cd62d4c4f8752DaACB09"), // cETH <-> WETHv2
 		new PairStableSwap(kit, "0xaEFc4e8cF655a182E8346B24c8AbcE45616eE0d2"), // cBTC <-> WBTCv2
 		new PairStableSwap(kit, "0xcCe0d62Ce14FB3e4363Eb92Db37Ff3630836c252"), // cUSD <-> pUSDCv2
-	])
+	], "Mobius")
 export const mainnetRegistrySavingsCELO =
 	(kit: ContractKit) =>  new RegistryStatic([
 		new PairSavingsCELO(kit, SavingsCELOAddressMainnet),
-	])
+	], "SavingsCELO")
 export const mainnetRegistryMoolaV2 =
-	(kit: ContractKit) => new RegistryAaveV2(kit, "0xD1088091A174d33412a968Fa34Cb67131188B332")
+	(kit: ContractKit) => new RegistryAaveV2(kit, "0xD1088091A174d33412a968Fa34Cb67131188B332", "MoolaV2")
 export const mainnetRegistryCeloDex =
 	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x31bD38d982ccDf3C2D95aF45a3456d319f0Ee1b6", {
 		fixedFee: new BigNumber(0.997), // TODO(zviadm): Figure out actual fee for CeloDex pairs.
 		fetchUsingAllPairs: true,
-	})
+	}, "CeloDex")
 
 // mainnetRegistriesWhitelist contains list of more established protocols with
 // overall higher TVL.

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,5 +1,15 @@
 import { Address, Pair } from "./pair";
 
-export interface Registry {
-	findPairs: (tokenWhitelist: Address[]) => Promise<Pair[]>
+export abstract class Registry {
+	private name: string
+
+	constructor(name: string) {
+		this.name = name
+	}
+
+	public getName(): string {
+		return this.name
+	}
+
+	public abstract findPairs(tokenWhitelist: Address[]): Promise<Pair[]>
 }

--- a/src/swappa-manager.ts
+++ b/src/swappa-manager.ts
@@ -81,7 +81,7 @@ export class SwappaManager {
 		return swapTX(this.kit, this.routerAddr, route, inputAmount, minOutputAmount, to, opts)
 	}
 
-	public lookupPairs(registry: Registry): Pair[] {
+	public getPairsByRegistry(registry: Registry): Pair[] {
 		return this.pairsByRegistry.get(registry) || []
 	}
 }

--- a/src/swappa-manager.ts
+++ b/src/swappa-manager.ts
@@ -12,7 +12,7 @@ import { findBestRoutesForFixedInputAmount, Route, RouterOpts } from "./router"
 export class SwappaManager {
 	private pairs: Pair[] = []
 	private pairsByToken = new Map<string, Pair[]>()
-	private pairsByRegistry = new Map<Registry, Pair[]>()
+	private pairsByRegistry = new Map<string, Pair[]>()
 
 	constructor(
 		private kit: ContractKit,
@@ -22,10 +22,10 @@ export class SwappaManager {
 	}
 
 	public reinitializePairs = async (tokenWhitelist: Address[]) => {
-		this.pairsByRegistry = new Map<Registry, Pair[]>()
+		this.pairsByRegistry = new Map<string, Pair[]>()
 		const pairsAll = await concurrentMap(5, this.registries, (r) =>
 			r.findPairs(tokenWhitelist).then(pairs => {
-				this.pairsByRegistry.set(r, pairs)
+				this.pairsByRegistry.set(r.getName(), pairs)
 				return pairs
 			})
 		)
@@ -81,7 +81,7 @@ export class SwappaManager {
 		return swapTX(this.kit, this.routerAddr, route, inputAmount, minOutputAmount, to, opts)
 	}
 
-	public getPairsByRegistry(registry: Registry): Pair[] {
+	public getPairsByRegistry(registry: string): Pair[] {
 		return this.pairsByRegistry.get(registry) || []
 	}
 }

--- a/src/swappa-manager.ts
+++ b/src/swappa-manager.ts
@@ -12,6 +12,7 @@ import { findBestRoutesForFixedInputAmount, Route, RouterOpts } from "./router"
 export class SwappaManager {
 	private pairs: Pair[] = []
 	private pairsByToken = new Map<string, Pair[]>()
+	private pairsByRegistry = new Map<Registry, Pair[]>()
 
 	constructor(
 		private kit: ContractKit,
@@ -21,7 +22,13 @@ export class SwappaManager {
 	}
 
 	public reinitializePairs = async (tokenWhitelist: Address[]) => {
-		const pairsAll = await concurrentMap(5, this.registries, (r) => r.findPairs(tokenWhitelist))
+		this.pairsByRegistry = new Map<Registry, Pair[]>()
+		const pairsAll = await concurrentMap(5, this.registries, (r) =>
+			r.findPairs(tokenWhitelist).then(pairs => {
+				this.pairsByRegistry.set(r, pairs)
+				return pairs
+			})
+		)
 		this.pairs = []
 		this.pairsByToken = new Map<string, Pair[]>()
 		pairsAll.forEach((pairs) => {
@@ -72,6 +79,10 @@ export class SwappaManager {
 		}
 		): CeloTransactionObject<unknown> => {
 		return swapTX(this.kit, this.routerAddr, route, inputAmount, minOutputAmount, to, opts)
+	}
+
+	public lookupPairs(registry: Registry): Pair[] {
+		return this.pairsByRegistry.get(registry) || []
 	}
 }
 


### PR DESCRIPTION
Motivations:
1. Provide debugging output to show exactly which registry is providing which pair
2. Be able to look up all of the pairs utilized by the swap manager from specific registry