### PR TITLE
Cross-chain compatibility for PairUniswapV2, PairStableSwap and PairATokenV2

### DIFF
--- a/src/pairs/atoken-v2.ts
+++ b/src/pairs/atoken-v2.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js"
-import { ContractKit } from "@celo/contractkit"
+import Web3 from "web3"
 
 import { ILendingPoolV2, ABI as ILendingPoolV2ABI } from "../../types/web3-v1-contracts/ILendingPoolV2"
 
@@ -13,12 +13,12 @@ export class PairATokenV2 extends Pair {
 	private pool: ILendingPoolV2
 
 	constructor(
-		private kit: ContractKit,
+		private web3: Web3,
 		private poolAddr: Address,
 		private reserve: Address,
 	) {
 		super()
-		this.pool = new this.kit.web3.eth.Contract(ILendingPoolV2ABI, this.poolAddr)
+		this.pool = new this.web3.eth.Contract(ILendingPoolV2ABI, this.poolAddr) as unknown as ILendingPoolV2
 	}
 
 	protected async _init() {
@@ -28,7 +28,7 @@ export class PairATokenV2 extends Pair {
 		return {
 			pairKey: null,
 			tokenA, tokenB,
-			swappaPairAddress: await selectAddress(this.kit, {mainnet: pairATokenV2Address})
+			swappaPairAddress: await selectAddress(this.web3, {mainnet: pairATokenV2Address})
 		}
 	}
 	public async refresh(): Promise<void> {}

--- a/src/pairs/atoken.ts
+++ b/src/pairs/atoken.ts
@@ -1,7 +1,8 @@
 import BigNumber from "bignumber.js"
+import Web3 from "web3"
 import { ContractKit } from "@celo/contractkit"
-import { ILendingPool, ABI as LendingPoolABI } from "../../types/web3-v1-contracts/ILendingPool";
-import { ILendingPoolAddressesProvider, ABI as LendingPoolAddressProviderABI } from "../../types/web3-v1-contracts/ILendingPoolAddressesProvider";
+import { ILendingPool, ABI as LendingPoolABI } from "../../types/web3-v1-contracts/ILendingPool"
+import { ILendingPoolAddressesProvider, ABI as LendingPoolAddressProviderABI } from "../../types/web3-v1-contracts/ILendingPoolAddressesProvider"
 
 import { Address, Pair } from "../pair"
 import { selectAddress } from "../utils"
@@ -34,7 +35,7 @@ export class PairAToken extends Pair {
 		return {
 			pairKey: null,
 			tokenA, tokenB,
-			swappaPairAddress: await selectAddress(this.kit, {mainnet: pairATokenAddress})
+			swappaPairAddress: await selectAddress(this.kit.web3 as unknown as Web3, {mainnet: pairATokenAddress})
 		}
 	}
 	public async refresh(): Promise<void> {}

--- a/src/pairs/mento.ts
+++ b/src/pairs/mento.ts
@@ -1,11 +1,13 @@
-import { ContractKit, StableToken } from "@celo/contractkit";
-import { ExchangeWrapper } from "@celo/contractkit/lib/wrappers/Exchange";
-import BigNumber from "bignumber.js";
-import { Address, PairXYeqK } from "../pair";
+import { ContractKit, StableToken } from "@celo/contractkit"
+import { ExchangeWrapper } from "@celo/contractkit/lib/wrappers/Exchange"
+import BigNumber from "bignumber.js"
+import Web3 from "web3"
+
+import { PairXYeqK } from "../pair"
 import { address as pairMentoAddress } from "../../tools/deployed/mainnet.PairMento.addr.json"
-import { ReserveWrapper } from "@celo/contractkit/lib/wrappers/Reserve";
-import { SortedOraclesWrapper } from "@celo/contractkit/lib/wrappers/SortedOracles";
-import { selectAddress } from "../utils";
+import { ReserveWrapper } from "@celo/contractkit/lib/wrappers/Reserve"
+import { SortedOraclesWrapper } from "@celo/contractkit/lib/wrappers/SortedOracles"
+import { selectAddress } from "../utils"
 
 export class PairMento extends PairXYeqK {
 	allowRepeats = false
@@ -31,7 +33,7 @@ export class PairMento extends PairXYeqK {
 			pairKey: this.exchange.address,
 			tokenA: celo.address,
 			tokenB: cSTB.address,
-			swappaPairAddress: await selectAddress(this.kit, {mainnet: pairMentoAddress})
+			swappaPairAddress: await selectAddress(this.kit.web3 as unknown as Web3, {mainnet: pairMentoAddress})
 		}
 	}
 

--- a/src/pairs/savingscelo.ts
+++ b/src/pairs/savingscelo.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js"
+import Web3 from "web3"
 import { ContractKit } from "@celo/contractkit"
 
 import { Address, Pair } from "../pair"
@@ -27,7 +28,7 @@ export class PairSavingsCELO extends Pair {
 		return {
 			pairKey: null,
 			tokenA, tokenB,
-			swappaPairAddress: await selectAddress(this.kit, {mainnet: pairSavingsCELOAddress})
+			swappaPairAddress: await selectAddress(this.kit.web3 as unknown as Web3, {mainnet: pairSavingsCELOAddress})
 		}
 	}
 	public async refresh(): Promise<void> {

--- a/src/pairs/stableswap.ts
+++ b/src/pairs/stableswap.ts
@@ -1,4 +1,4 @@
-import { ContractKit } from "@celo/contractkit"
+import Web3 from "web3"
 import BigNumber from "bignumber.js"
 
 import { ISwap, ABI as SwapABI } from "../../types/web3-v1-contracts/ISwap"
@@ -22,11 +22,11 @@ export class PairStableSwap extends Pair {
 	static readonly A_PRECISION = 100
 
 	constructor(
-		private kit: ContractKit,
+		private web3: Web3,
 		private swapPoolAddr: Address,
 	) {
 		super()
-		this.swapPool = new kit.web3.eth.Contract(SwapABI, swapPoolAddr) as unknown as ISwap
+		this.swapPool = new web3.eth.Contract(SwapABI, swapPoolAddr) as unknown as ISwap
 	}
 
 	protected async _init() {
@@ -37,10 +37,10 @@ export class PairStableSwap extends Pair {
 		] = await Promise.all([
 			this.swapPool.methods.getToken(0).call(),
 			this.swapPool.methods.getToken(1).call(),
-			selectAddress(this.kit, {mainnet: pairStableSwapAddress}),
+			selectAddress(this.web3, {mainnet: pairStableSwapAddress}),
 		])
-		const erc20A = new this.kit.web3.eth.Contract(Erc20ABI, tokenA) as unknown as Erc20
-		const erc20B = new this.kit.web3.eth.Contract(Erc20ABI, tokenB) as unknown as Erc20
+		const erc20A = new this.web3.eth.Contract(Erc20ABI, tokenA) as unknown as Erc20
+		const erc20B = new this.web3.eth.Contract(Erc20ABI, tokenB) as unknown as Erc20
 		const [
 			decimalsA,
 			decimalsB,

--- a/src/pairs/uniswapv2.ts
+++ b/src/pairs/uniswapv2.ts
@@ -1,6 +1,6 @@
-import { ContractKit } from "@celo/contractkit"
+import Web3 from "web3"
 import BigNumber from "bignumber.js"
-import { IUniswapV2Factory, ABI as FactoryABI } from "../../types/web3-v1-contracts/IUniswapV2Factory"
+
 import { IUniswapV2Pair, ABI as PairABI } from "../../types/web3-v1-contracts/IUniswapV2Pair"
 import { Address, PairXYeqK } from "../pair"
 import { address as pairUniswapV2Address } from "../../tools/deployed/mainnet.PairUniswapV2.addr.json"
@@ -13,15 +13,15 @@ export class PairUniswapV2 extends PairXYeqK {
 	private feeKData: string
 
 	constructor(
-		private kit: ContractKit,
+		private web3: Web3,
 		private pairAddr: Address,
 		private fixedFee: BigNumber = new BigNumber(0.997),
 	) {
 		super()
-		this.pair = new this.kit.web3.eth.Contract(PairABI, pairAddr) as unknown as IUniswapV2Pair
+		this.pair = new this.web3.eth.Contract(PairABI, pairAddr) as unknown as IUniswapV2Pair
 		const feeKInv = new BigNumber(1000).minus(this.fixedFee.multipliedBy(1000))
 		if (!feeKInv.isInteger() || !feeKInv.gt(0) || !feeKInv.lt(100)) {
-			throw new Error(`Invalida fixedFee: ${this.fixedFee}!`)
+			throw new Error(`Invalid fixedFee: ${this.fixedFee}!`)
 		}
 		this.feeKData = feeKInv.toString(16).padStart(2, "0")
 	}
@@ -30,7 +30,7 @@ export class PairUniswapV2 extends PairXYeqK {
 		const [tokenA, tokenB, swappaPairAddress] = await Promise.all([
 			this.pair.methods.token0().call(),
 			this.pair.methods.token1().call(),
-			selectAddress(this.kit, {mainnet: pairUniswapV2Address}),
+			selectAddress(this.web3, {mainnet: pairUniswapV2Address}),
 		])
 		return {
 			pairKey: this.pairAddr,

--- a/src/registries/aave-v2.ts
+++ b/src/registries/aave-v2.ts
@@ -1,4 +1,4 @@
-import { ContractKit } from "@celo/contractkit"
+import Web3 from "web3"
 
 import { ILendingPoolV2, ABI as ILendingPoolV2ABI } from "../../types/web3-v1-contracts/ILendingPoolV2"
 import { ILendingPoolAddressesProviderV2, ABI as ILendingPoolAddressesProviderV2ABI } from "../../types/web3-v1-contracts/ILendingPoolAddressesProviderV2"
@@ -10,16 +10,16 @@ import { PairATokenV2 } from "../pairs/atoken-v2"
 export class RegistryAaveV2 {
 	private provider: ILendingPoolAddressesProviderV2
 
-	constructor(private kit: ContractKit, lendingPoolAddrProviderAddr: string) {
-		this.provider = new kit.web3.eth.Contract(ILendingPoolAddressesProviderV2ABI, lendingPoolAddrProviderAddr)
+	constructor(private web3: Web3, lendingPoolAddrProviderAddr: string) {
+		this.provider = new web3.eth.Contract(ILendingPoolAddressesProviderV2ABI, lendingPoolAddrProviderAddr) as unknown as ILendingPoolAddressesProviderV2
 	}
 
 	findPairs = async (tokenWhitelist: Address[]) => {
 		const poolAddr: string = await this.provider.methods.getLendingPool().call()
-		const lendingPool: ILendingPoolV2 = new this.kit.web3.eth.Contract(ILendingPoolV2ABI, poolAddr)
+		const lendingPool: ILendingPoolV2 = new this.web3.eth.Contract(ILendingPoolV2ABI, poolAddr) as unknown as ILendingPoolV2
 		const reserves: Address[] = await lendingPool.methods.getReservesList().call()
 		const reservesMatched = reserves.filter((r) => tokenWhitelist.indexOf(r) >= 0)
-		const pairs = reservesMatched.map((r) => (new PairATokenV2(this.kit, poolAddr, r)))
+		const pairs = reservesMatched.map((r) => (new PairATokenV2(this.web3, poolAddr, r)))
 		return initPairsAndFilterByWhitelist(pairs, tokenWhitelist)
 	}
 }

--- a/src/registries/uniswapv2.ts
+++ b/src/registries/uniswapv2.ts
@@ -1,24 +1,24 @@
-import BigNumber from "bignumber.js";
-import { ContractKit } from "@celo/contractkit";
+import BigNumber from "bignumber.js"
+import Web3 from "web3"
 import { concurrentMap } from '@celo/utils/lib/async'
 
-import { IUniswapV2Factory, ABI as FactoryABI } from "../../types/web3-v1-contracts/IUniswapV2Factory";
-import { Address, Pair } from "../pair";
-import { PairUniswapV2 } from "../pairs/uniswapv2";
-import { initPairsAndFilterByWhitelist } from "../utils";
+import { IUniswapV2Factory, ABI as FactoryABI } from "../../types/web3-v1-contracts/IUniswapV2Factory"
+import { Address, Pair } from "../pair"
+import { PairUniswapV2 } from "../pairs/uniswapv2"
+import { initPairsAndFilterByWhitelist } from "../utils"
 
 export class RegistryUniswapV2 {
 	private factory: IUniswapV2Factory
 
 	constructor(
-		private kit: ContractKit,
+		private web3: Web3,
 		factoryAddr: Address,
 		private opts?: {
 			fixedFee?: BigNumber,
 			fetchUsingAllPairs?: boolean,
 		},
 	) {
-		this.factory = new kit.web3.eth.Contract(FactoryABI, factoryAddr) as unknown as IUniswapV2Factory
+		this.factory = new web3.eth.Contract(FactoryABI, factoryAddr) as unknown as IUniswapV2Factory
 	}
 
 	findPairs = async (tokenWhitelist: Address[]): Promise<Pair[]> =>  {
@@ -38,7 +38,7 @@ export class RegistryUniswapV2 {
 					if (pairAddr === "0x0000000000000000000000000000000000000000") {
 						return null
 					}
-					return new PairUniswapV2(this.kit, pairAddr, this.opts?.fixedFee)
+					return new PairUniswapV2(this.web3, pairAddr, this.opts?.fixedFee)
 				})
 		} else {
 			const nPairs = Number.parseInt(await this.factory.methods.allPairsLength().call())
@@ -47,7 +47,7 @@ export class RegistryUniswapV2 {
 				[...Array(nPairs).keys()],
 				async (idx) => {
 					const pairAddr = await this.factory.methods.allPairs(idx).call()
-					return new PairUniswapV2(this.kit, pairAddr, this.opts?.fixedFee)
+					return new PairUniswapV2(this.web3, pairAddr, this.opts?.fixedFee)
 				})
 		}
 		const pairs = pairsFetched.filter((p) => p !== null) as Pair[]

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js"
+import Web3 from "web3"
 import { ContractKit } from "@celo/contractkit"
 import { SavingsCELOAddressMainnet } from "@terminal-fi/savingscelo"
 import { PairSavingsCELO } from "./pairs/savingscelo"

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -12,38 +12,38 @@ import { RegistryUniswapV2 } from "./registries/uniswapv2"
 export const mainnetRegistryMoola =
 	(kit: ContractKit) => new RegistryAave(kit, "0x7AAaD5a5fa74Aec83b74C2a098FBC86E17Ce4aEA")
 export const mainnetRegistryUbeswap =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x62d5b84bE28a183aBB507E125B384122D2C25fAE")
+	(kit: ContractKit) => new RegistryUniswapV2(kit.web3 as unknown as Web3, "0x62d5b84bE28a183aBB507E125B384122D2C25fAE")
 export const mainnetRegistrySushiswap =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
+	(kit: ContractKit) => new RegistryUniswapV2(kit.web3 as unknown as Web3, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
 export const mainnetRegistryMobius =
 	(kit: ContractKit) => new RegistryStatic([
 		// Source: https://github.com/mobiusAMM/mobiusV1
-		new PairStableSwap(kit, "0x0ff04189Ef135b6541E56f7C638489De92E9c778"), // cUSD <-> bUSDC
-		new PairStableSwap(kit, "0xdBF27fD2a702Cc02ac7aCF0aea376db780D53247"), // cUSD <-> cUSDT
-		new PairStableSwap(kit, "0xE0F2cc70E52f05eDb383313393d88Df2937DA55a"), // cETH <-> WETH
-		new PairStableSwap(kit, "0x19260b9b573569dDB105780176547875fE9fedA3"), //  BTC <-> WBTC
-		new PairStableSwap(kit, "0xA5037661989789d0310aC2B796fa78F1B01F195D"), // cUSD <-> USDC
-		new PairStableSwap(kit, "0x2080AAa167e2225e1FC9923250bA60E19a180Fb2"), // cUSD <-> pUSDC
-		new PairStableSwap(kit, "0x63C1914bf00A9b395A2bF89aaDa55A5615A3656e"), // cUSD <-> asUSDC
-		new PairStableSwap(kit, "0x382Ed834c6b7dBD10E4798B08889eaEd1455E820"), // cEUR <-> pEUR
-		new PairStableSwap(kit, "0x413FfCc28e6cDDE7e93625Ef4742810fE9738578"), // CELO <-> pCELO
-		new PairStableSwap(kit, "0x02Db089fb09Fda92e05e92aFcd41D9AAfE9C7C7C"), // cUSD <-> pUSD
-		new PairStableSwap(kit, "0x0986B42F5f9C42FeEef66fC23eba9ea1164C916D"), // cUSD <-> aaUSDC
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x0ff04189Ef135b6541E56f7C638489De92E9c778"), // cUSD <-> bUSDC
+		new PairStableSwap(kit.web3 as unknown as Web3, "0xdBF27fD2a702Cc02ac7aCF0aea376db780D53247"), // cUSD <-> cUSDT
+		new PairStableSwap(kit.web3 as unknown as Web3, "0xE0F2cc70E52f05eDb383313393d88Df2937DA55a"), // cETH <-> WETH
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x19260b9b573569dDB105780176547875fE9fedA3"), //  BTC <-> WBTC
+		new PairStableSwap(kit.web3 as unknown as Web3, "0xA5037661989789d0310aC2B796fa78F1B01F195D"), // cUSD <-> USDC
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x2080AAa167e2225e1FC9923250bA60E19a180Fb2"), // cUSD <-> pUSDC
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x63C1914bf00A9b395A2bF89aaDa55A5615A3656e"), // cUSD <-> asUSDC
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x382Ed834c6b7dBD10E4798B08889eaEd1455E820"), // cEUR <-> pEUR
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x413FfCc28e6cDDE7e93625Ef4742810fE9738578"), // CELO <-> pCELO
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x02Db089fb09Fda92e05e92aFcd41D9AAfE9C7C7C"), // cUSD <-> pUSD
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x0986B42F5f9C42FeEef66fC23eba9ea1164C916D"), // cUSD <-> aaUSDC
 		// Opticsv2: https://github.com/mobiusAMM/mobius-interface/blob/main/src/constants/StablePools.ts
-		new PairStableSwap(kit, "0x9906589Ea8fd27504974b7e8201DF5bBdE986b03"), // cUSD <-> USDCv2
-		new PairStableSwap(kit, "0xF3f65dFe0c8c8f2986da0FEc159ABE6fd4E700B4"), // cUSD <-> DAIv2
-		new PairStableSwap(kit, "0x74ef28D635c6C5800DD3Cd62d4c4f8752DaACB09"), // cETH <-> WETHv2
-		new PairStableSwap(kit, "0xaEFc4e8cF655a182E8346B24c8AbcE45616eE0d2"), // cBTC <-> WBTCv2
-		new PairStableSwap(kit, "0xcCe0d62Ce14FB3e4363Eb92Db37Ff3630836c252"), // cUSD <-> pUSDCv2
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x9906589Ea8fd27504974b7e8201DF5bBdE986b03"), // cUSD <-> USDCv2
+		new PairStableSwap(kit.web3 as unknown as Web3, "0xF3f65dFe0c8c8f2986da0FEc159ABE6fd4E700B4"), // cUSD <-> DAIv2
+		new PairStableSwap(kit.web3 as unknown as Web3, "0x74ef28D635c6C5800DD3Cd62d4c4f8752DaACB09"), // cETH <-> WETHv2
+		new PairStableSwap(kit.web3 as unknown as Web3, "0xaEFc4e8cF655a182E8346B24c8AbcE45616eE0d2"), // cBTC <-> WBTCv2
+		new PairStableSwap(kit.web3 as unknown as Web3, "0xcCe0d62Ce14FB3e4363Eb92Db37Ff3630836c252"), // cUSD <-> pUSDCv2
 	])
 export const mainnetRegistrySavingsCELO =
 	(kit: ContractKit) =>  new RegistryStatic([
 		new PairSavingsCELO(kit, SavingsCELOAddressMainnet),
 	])
 export const mainnetRegistryMoolaV2 =
-	(kit: ContractKit) => new RegistryAaveV2(kit, "0xD1088091A174d33412a968Fa34Cb67131188B332")
+	(kit: ContractKit) => new RegistryAaveV2(kit.web3 as unknown as Web3, "0xD1088091A174d33412a968Fa34Cb67131188B332")
 export const mainnetRegistryCeloDex =
-	(kit: ContractKit) => new RegistryUniswapV2(kit, "0x31bD38d982ccDf3C2D95aF45a3456d319f0Ee1b6", {
+	(kit: ContractKit) => new RegistryUniswapV2(kit.web3 as unknown as Web3, "0x31bD38d982ccDf3C2D95aF45a3456d319f0Ee1b6", {
 		fixedFee: new BigNumber(0.997), // TODO(zviadm): Figure out actual fee for CeloDex pairs.
 		fetchUsingAllPairs: true,
 	})

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -16,26 +16,29 @@ export const mainnetRegistryUbeswap =
 export const mainnetRegistrySushiswap =
 	(kit: ContractKit) => new RegistryUniswapV2(kit.web3 as unknown as Web3, "0xc35DADB65012eC5796536bD9864eD8773aBc74C4")
 export const mainnetRegistryMobius =
-	(kit: ContractKit) => new RegistryStatic([
-		// Source: https://github.com/mobiusAMM/mobiusV1
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x0ff04189Ef135b6541E56f7C638489De92E9c778"), // cUSD <-> bUSDC
-		new PairStableSwap(kit.web3 as unknown as Web3, "0xdBF27fD2a702Cc02ac7aCF0aea376db780D53247"), // cUSD <-> cUSDT
-		new PairStableSwap(kit.web3 as unknown as Web3, "0xE0F2cc70E52f05eDb383313393d88Df2937DA55a"), // cETH <-> WETH
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x19260b9b573569dDB105780176547875fE9fedA3"), //  BTC <-> WBTC
-		new PairStableSwap(kit.web3 as unknown as Web3, "0xA5037661989789d0310aC2B796fa78F1B01F195D"), // cUSD <-> USDC
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x2080AAa167e2225e1FC9923250bA60E19a180Fb2"), // cUSD <-> pUSDC
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x63C1914bf00A9b395A2bF89aaDa55A5615A3656e"), // cUSD <-> asUSDC
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x382Ed834c6b7dBD10E4798B08889eaEd1455E820"), // cEUR <-> pEUR
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x413FfCc28e6cDDE7e93625Ef4742810fE9738578"), // CELO <-> pCELO
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x02Db089fb09Fda92e05e92aFcd41D9AAfE9C7C7C"), // cUSD <-> pUSD
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x0986B42F5f9C42FeEef66fC23eba9ea1164C916D"), // cUSD <-> aaUSDC
-		// Opticsv2: https://github.com/mobiusAMM/mobius-interface/blob/main/src/constants/StablePools.ts
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x9906589Ea8fd27504974b7e8201DF5bBdE986b03"), // cUSD <-> USDCv2
-		new PairStableSwap(kit.web3 as unknown as Web3, "0xF3f65dFe0c8c8f2986da0FEc159ABE6fd4E700B4"), // cUSD <-> DAIv2
-		new PairStableSwap(kit.web3 as unknown as Web3, "0x74ef28D635c6C5800DD3Cd62d4c4f8752DaACB09"), // cETH <-> WETHv2
-		new PairStableSwap(kit.web3 as unknown as Web3, "0xaEFc4e8cF655a182E8346B24c8AbcE45616eE0d2"), // cBTC <-> WBTCv2
-		new PairStableSwap(kit.web3 as unknown as Web3, "0xcCe0d62Ce14FB3e4363Eb92Db37Ff3630836c252"), // cUSD <-> pUSDCv2
-	])
+	(kit: ContractKit) => {
+		const web3 = kit.web3 as unknown as Web3
+		return new RegistryStatic([
+			// Source: https://github.com/mobiusAMM/mobiusV1
+			new PairStableSwap(web3, "0x0ff04189Ef135b6541E56f7C638489De92E9c778"), // cUSD <-> bUSDC
+			new PairStableSwap(web3, "0xdBF27fD2a702Cc02ac7aCF0aea376db780D53247"), // cUSD <-> cUSDT
+			new PairStableSwap(web3, "0xE0F2cc70E52f05eDb383313393d88Df2937DA55a"), // cETH <-> WETH
+			new PairStableSwap(web3, "0x19260b9b573569dDB105780176547875fE9fedA3"), //  BTC <-> WBTC
+			new PairStableSwap(web3, "0xA5037661989789d0310aC2B796fa78F1B01F195D"), // cUSD <-> USDC
+			new PairStableSwap(web3, "0x2080AAa167e2225e1FC9923250bA60E19a180Fb2"), // cUSD <-> pUSDC
+			new PairStableSwap(web3, "0x63C1914bf00A9b395A2bF89aaDa55A5615A3656e"), // cUSD <-> asUSDC
+			new PairStableSwap(web3, "0x382Ed834c6b7dBD10E4798B08889eaEd1455E820"), // cEUR <-> pEUR
+			new PairStableSwap(web3, "0x413FfCc28e6cDDE7e93625Ef4742810fE9738578"), // CELO <-> pCELO
+			new PairStableSwap(web3, "0x02Db089fb09Fda92e05e92aFcd41D9AAfE9C7C7C"), // cUSD <-> pUSD
+			new PairStableSwap(web3, "0x0986B42F5f9C42FeEef66fC23eba9ea1164C916D"), // cUSD <-> aaUSDC
+			// Opticsv2: https://github.com/mobiusAMM/mobius-interface/blob/main/src/constants/StablePools.ts
+			new PairStableSwap(web3, "0x9906589Ea8fd27504974b7e8201DF5bBdE986b03"), // cUSD <-> USDCv2
+			new PairStableSwap(web3, "0xF3f65dFe0c8c8f2986da0FEc159ABE6fd4E700B4"), // cUSD <-> DAIv2
+			new PairStableSwap(web3, "0x74ef28D635c6C5800DD3Cd62d4c4f8752DaACB09"), // cETH <-> WETHv2
+			new PairStableSwap(web3, "0xaEFc4e8cF655a182E8346B24c8AbcE45616eE0d2"), // cBTC <-> WBTCv2
+			new PairStableSwap(web3, "0xcCe0d62Ce14FB3e4363Eb92Db37Ff3630836c252"), // cUSD <-> pUSDCv2
+		])
+	}
 export const mainnetRegistrySavingsCELO =
 	(kit: ContractKit) =>  new RegistryStatic([
 		new PairSavingsCELO(kit, SavingsCELOAddressMainnet),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { ContractKit } from "@celo/contractkit"
+import Web3 from "web3"
 import { concurrentMap } from '@celo/utils/lib/async'
 
 import { Address, Pair } from "./pair"
@@ -17,8 +17,8 @@ interface AddressesByNetwork {
 	alfajores?: Address,
 }
 
-export const selectAddress = async (kit: ContractKit, addresses: AddressesByNetwork) => {
-	const chainId = await kit.web3.eth.getChainId()
+export const selectAddress = async (web3: Web3, addresses: AddressesByNetwork) => {
+	const chainId = await web3.eth.getChainId()
 	return selectAddressUsingChainId(chainId, addresses)
 }
 
@@ -26,17 +26,17 @@ export const selectAddressUsingChainId = (chainId: number, addresses: AddressesB
 	switch (chainId) {
 	case 42220:
 		if (!addresses.mainnet) {
-			throw new Error(`no address provided for Mainnet (42220)!`)
+			throw new Error(`no address provided for Mainnet (${chainId})!`)
 		}
 		return addresses.mainnet
 	case 62320:
 		if (!addresses.baklava) {
-			throw new Error(`no address provided for Baklava (62320)!`)
+			throw new Error(`no address provided for Baklava (${chainId})!`)
 		}
 		return addresses.baklava
 	case 44787:
 		if (!addresses.alfajores) {
-			throw new Error(`no address provided for Alfajores (44787)!`)
+			throw new Error(`no address provided for Alfajores (${chainId})!`)
 		}
 		return addresses.alfajores
 	default:


### PR DESCRIPTION
These pair implementations are cross-chain compatible if we just make them take in `Web3` instead of `ContractKit`.

Need these compatibility changes so that Swappa can be deployed on other EVM compatible networks.

`PairAToken` should also be easily cross-chained with some more changes but it's not really important even on other chains.