### PR TITLE
Connect the multiple pairs of the same Balancer BPool

### DIFF
--- a/src/pairs/bpool.ts
+++ b/src/pairs/bpool.ts
@@ -26,6 +26,7 @@ export class PairBPool extends Pair {
 	private weightB: BigNumber = ZERO
 	private balanceA: BigNumber = ZERO
 	private balanceB: BigNumber = ZERO
+	private siblings: PairBPool[] = []
 
 	constructor(
 		private web3: Web3,
@@ -47,7 +48,6 @@ export class PairBPool extends Pair {
 			this.bPool.methods.getSwapFee().call(),
 			this.bPool.methods.getDenormalizedWeight(this.tokenA).call(),
 			this.bPool.methods.getDenormalizedWeight(this.tokenB).call(),
-			// TODO: change this after merge to the actual deployed PairBPool swap address
 			selectAddress(this.web3, {mainnet: pairBPoolAddress})
 		])
 		this.swapFee = new BigNumber(swapFee).div(BONE)
@@ -110,11 +110,20 @@ export class PairBPool extends Pair {
 			balanceB: this.balanceB.toFixed()
 		}
 	}
+
 	public restore(snapshot: PairBPoolSnapshot): void {
 		this.swapFee = new BigNumber(snapshot.swapFee)
 		this.weightA = new BigNumber(snapshot.weightA)
 		this.weightB = new BigNumber(snapshot.weightB)
 		this.balanceA = new BigNumber(snapshot.balanceA)
 		this.balanceB = new BigNumber(snapshot.balanceB)
+	}
+
+	public setSiblings(siblings: PairBPool[]): void {
+		this.siblings = siblings
+	}
+
+	public getSiblings(): PairBPool[] {
+		return this.siblings
 	}
 }

--- a/src/pairs/bpool.ts
+++ b/src/pairs/bpool.ts
@@ -26,6 +26,10 @@ export class PairBPool extends Pair {
 	private weightB: BigNumber = ZERO
 	private balanceA: BigNumber = ZERO
 	private balanceB: BigNumber = ZERO
+
+	// Balancer pools with more than 2 tokens are repeated as the pair-wise combinations.
+	// siblings is used to keep track of all of the PairBPool that represent the same poolAddr.
+	// The same array instance is set by the RegistryBalancer on all of the pair-wise PairBPools.
 	private siblings: PairBPool[] = []
 
 	constructor(


### PR DESCRIPTION
For balancer BPool with more than 2 tokens, the same underlying pool is represented repeatedly as each pair-wise combination.

So for pool with 3 tokens, there are 3 unique pairs pointed to the same pool address.
Add a `siblings` array that connect the three pairs together.

This will be useful if we ever want to be sophisticated and run a swap route that utilizes a single BPool repeatedly via different input & output pairs.