### PR TITLE
Remove unsafe SavingsCelo from registry whitelist and CLI

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -11,7 +11,7 @@ import { address as swappaRouterV1Address} from '../../tools/deployed/mainnet.Sw
 import { SwappaManager } from '../swappa-manager';
 import {
 	mainnetRegistryMobius, mainnetRegistryMoola, mainnetRegistryMoolaV2,
-	mainnetRegistrySavingsCELO, mainnetRegistrySushiswap, mainnetRegistryUbeswap,
+	mainnetRegistrySushiswap, mainnetRegistryUbeswap,
 	mainnetRegistryCeloDex, mainnetRegistrySymmetric
 } from '../registry-cfg';
 import { RegistryMento } from '../registries/mento';
@@ -42,7 +42,6 @@ const registriesByName: {[name: string]: (kit: ContractKit) => Registry} = {
 	"mobius":      mainnetRegistryMobius,
 	"moola":       mainnetRegistryMoola,
 	"moola-v2":    mainnetRegistryMoolaV2,
-	"savingscelo": mainnetRegistrySavingsCELO,
 	"celodex":     mainnetRegistryCeloDex,
 	"symmetric":   mainnetRegistrySymmetric,
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -11,7 +11,7 @@ import { address as swappaRouterV1Address} from '../../tools/deployed/mainnet.Sw
 import { SwappaManager } from '../swappa-manager';
 import {
 	mainnetRegistryMobius, mainnetRegistryMoola, mainnetRegistryMoolaV2,
-	mainnetRegistrySushiswap, mainnetRegistryUbeswap,
+	mainnetRegistrySavingsCELO, mainnetRegistrySushiswap, mainnetRegistryUbeswap,
 	mainnetRegistryCeloDex, mainnetRegistrySymmetric
 } from '../registry-cfg';
 import { RegistryMento } from '../registries/mento';
@@ -42,6 +42,7 @@ const registriesByName: {[name: string]: (kit: ContractKit) => Registry} = {
 	"mobius":      mainnetRegistryMobius,
 	"moola":       mainnetRegistryMoola,
 	"moola-v2":    mainnetRegistryMoolaV2,
+	"savingscelo": mainnetRegistrySavingsCELO,
 	"celodex":     mainnetRegistryCeloDex,
 	"symmetric":   mainnetRegistrySymmetric,
 }

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -78,5 +78,4 @@ export const mainnetRegistriesWhitelist = (kit: ContractKit) => ([
 	// Direct conversion protocols:
 	mainnetRegistryMoola(kit),
 	mainnetRegistryMoolaV2(kit),
-	mainnetRegistrySavingsCELO(kit),
 ])


### PR DESCRIPTION
SavingsCelo is a one-way street, you can only swap Celo into it but not out of it.

Remove it from the registry whitelist and do not include in the CLI tool.

SCelo is being wind down, don't let people swap more into it accidentally.