### PR TITLE
Misc fixes to PairBPool and pair

### DIFF
--- a/src/pair.ts
+++ b/src/pair.ts
@@ -71,6 +71,9 @@ export abstract class PairXYeqK extends Pair {
 		if (buckets === null) {
 			throw new Error(`unsupported input: ${inputToken}, pair: ${this.tokenA}/${this.tokenB}!`)
 		}
+		if (this.bucketA.lt(1) || this.bucketB.lt(1)) {
+			return new BigNumber(0)
+		}
 		const amountWithFee = inputAmount.multipliedBy(this.fee)
 		const outputAmount = buckets[1].multipliedBy(amountWithFee).dividedToIntegerBy(buckets[0].plus(amountWithFee))
 		return !outputAmount.isNaN() ? outputAmount : new BigNumber(0)

--- a/src/pairs/bpool.ts
+++ b/src/pairs/bpool.ts
@@ -11,9 +11,6 @@ const ONE = new BigNumber(1)
 const BONE = new BigNumber(10 ** 18)
 
 interface PairBPoolSnapshot extends Snapshot {
-	swapFee: BigNumberString
-	weightA: BigNumberString
-	weightB: BigNumberString
 	balanceA: BigNumberString
 	balanceB: BigNumberString
 }
@@ -76,6 +73,10 @@ export class PairBPool extends Pair {
 	}
 
 	public outputAmount(inputToken: Address, inputAmount: BigNumber): BigNumber {
+		if (this.balanceA.lt(1) || this.balanceB.lt(1)) {
+			return ZERO
+		}
+
 		let tokenBalanceIn, tokenBalanceOut, tokenWeightIn, tokenWeightOut
 		if (inputToken === this.tokenA) {
 			[tokenBalanceIn, tokenWeightIn, tokenBalanceOut, tokenWeightOut] = [
@@ -103,17 +104,11 @@ export class PairBPool extends Pair {
 
 	public snapshot(): PairBPoolSnapshot {
 		return {
-			swapFee: this.swapFee.toFixed(),
-			weightA: this.weightA.toFixed(),
-			weightB: this.weightB.toFixed(),
 			balanceA: this.balanceA.toFixed(),
 			balanceB: this.balanceB.toFixed()
 		}
 	}
 	public restore(snapshot: PairBPoolSnapshot): void {
-		this.swapFee = new BigNumber(snapshot.swapFee)
-		this.weightA = new BigNumber(snapshot.weightA)
-		this.weightB = new BigNumber(snapshot.weightB)
 		this.balanceA = new BigNumber(snapshot.balanceA)
 		this.balanceB = new BigNumber(snapshot.balanceB)
 	}


### PR DESCRIPTION
Fixes:
- if pools somehow have 0 for any of the bucket, output is 0 (symmetric does have empty pools)
- Balancer pool once finalized cannot have their fees or weights change, so no need to capture the weight or fee in the pair state snapshot, it's part of the initialization data instead