### PR TITLE
Ube token list is out of date

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@celo/connect": "^1.2.4",
     "@celo/contractkit": "^1.2.4",
     "@terminal-fi/savingscelo": "^3.4.0",
-    "@ubeswap/default-token-list": "^4.0.11",
+    "@ubeswap/default-token-list": "^4.1.42",
     "bignumber.js": "^9.0.1",
     "web3": "^1.3.4",
     "web3-utils": "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,10 +2675,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@ubeswap/default-token-list@^4.0.11":
-  version "4.0.29"
-  resolved "https://registry.yarnpkg.com/@ubeswap/default-token-list/-/default-token-list-4.0.29.tgz#ae5659126da231a98712eaef85856cef08e18afc"
-  integrity sha512-0GgBptMAz5XxB6cHrnM/eNVA/w1FUfuZl1OVrAiw2KFmLHeRDy2KbJMoal/OTRnW402CCMETvYjWYLTWDwn3iQ==
+"@ubeswap/default-token-list@^4.1.42":
+  version "4.1.42"
+  resolved "https://registry.yarnpkg.com/@ubeswap/default-token-list/-/default-token-list-4.1.42.tgz#9917bf221a96d033032acc2fa0e66607f7efbc3c"
+  integrity sha512-GnbAZ5Qb33NG1/yPw8yHRKNfRre3UOKhTrlM4pop8hflxMeIWLyIbGJujeGZqUG77nvkBcQfrO8nlp3DV6qXoA==
 
 "@wry/context@^0.6.0":
   version "0.6.1"


### PR DESCRIPTION
The names of the Optics v1 v2 tokens are out of date in the old ube token list, so CLI was giving me incorrect sanity check answers.

Example is DAI became DAIv1, WETH, etc... all of the optics V1 token had their symbols changed.

This will make the CLI output more correct
