### PR TITLE
Add Symmetric v1:v2 migration swap

### DIFF
--- a/contracts/interfaces/symmetric/ISymmetricSwap.sol
+++ b/contracts/interfaces/symmetric/ISymmetricSwap.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.8;
+
+interface ISymmetricSwap {
+	function paused() external view returns (bool);
+	function swap(
+		address from,
+		address to,
+		uint256 amount
+	) external;
+}

--- a/contracts/swappa/PairSymmetricSwap.sol
+++ b/contracts/swappa/PairSymmetricSwap.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.8;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../interfaces/symmetric/ISymmetricSwap.sol";
+import "./ISwappaPairV1.sol";
+
+contract PairSymmetricSwap is ISwappaPairV1 {
+	using SafeMath for uint;
+
+	function swap(
+		address input,
+		address output,
+		address to,
+		bytes calldata data
+	) external override {
+		address swapPoolAddr = parseData(data);
+		uint inputAmount = ERC20(input).balanceOf(address(this));
+		require(
+			ERC20(input).approve(swapPoolAddr, inputAmount),
+			"PairSymmetricSwap: approve failed!");
+		ISymmetricSwap(swapPoolAddr).swap(
+			input,
+			output,
+			inputAmount);
+		require(
+			ERC20(output).transfer(to, inputAmount),
+			"PairSymmetricSwap: transfer failed!");
+	}
+
+	function parseData(bytes memory data) private pure returns (address swapPoolAddr) {
+		require(data.length == 20, "PairSymmetricSwap: invalid data!");
+		assembly {
+			swapPoolAddr := mload(add(data, 20))
+		}
+	}
+
+	function getOutputAmount(
+		address input,
+		address output,
+		uint amountIn,
+		bytes calldata data
+	) external view override returns (uint amountOut) {
+		// no fees are taken
+		return amountIn;
+	}
+}

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -12,7 +12,7 @@ import { SwappaManager } from '../swappa-manager';
 import {
 	mainnetRegistryMobius, mainnetRegistryMoola, mainnetRegistryMoolaV2,
 	mainnetRegistrySavingsCELO, mainnetRegistrySushiswap, mainnetRegistryUbeswap,
-	mainnetRegistryCeloDex, mainnetRegistrySymmetric
+	mainnetRegistryCeloDex, mainnetRegistrySymmetric, mainnetRegistryMisc,
 } from '../registry-cfg';
 import { RegistryMento } from '../registries/mento';
 import { Registry } from '../registry';
@@ -46,6 +46,7 @@ const registriesByName: {[name: string]: (kit: ContractKit) => Registry} = {
 	"savingscelo": mainnetRegistrySavingsCELO,
 	"celodex":     mainnetRegistryCeloDex,
 	"symmetric":   mainnetRegistrySymmetric,
+	"misc":        mainnetRegistryMisc,
 }
 
 function tokenByAddrOrSymbol(addressOrSymbol: string) {

--- a/src/pairs/symmetricswap.ts
+++ b/src/pairs/symmetricswap.ts
@@ -33,7 +33,7 @@ export class PairSymmetricSwap extends Pair {
 		return {
 			pairKey: this.swapPoolAddr,
 			tokenA: this.tokenA,
-            tokenB: this.tokenA,
+            tokenB: this.tokenB,
             swappaPairAddress
         }
 	}

--- a/src/pairs/symmetricswap.ts
+++ b/src/pairs/symmetricswap.ts
@@ -1,0 +1,65 @@
+import Web3 from "web3"
+import BigNumber from "bignumber.js"
+
+import { ISymmetricSwap, ABI as SwapABI } from "../../types/web3-v1-contracts/ISymmetricSwap"
+import { Address, Pair, Snapshot } from "../pair"
+import { selectAddress } from "../utils"
+import { address as pairSymmetricSwapAddress } from "../../tools/deployed/mainnet.PairSymmetricSwap.addr.json"
+
+interface PairSymmetricSwapSnapshot extends Snapshot {
+	paused: boolean
+}
+
+const ZERO = new BigNumber(0)
+
+export class PairSymmetricSwap extends Pair {
+	allowRepeats = false
+	private swapPool: ISymmetricSwap
+
+	private paused: boolean = false
+
+	constructor(
+		private web3: Web3,
+		private swapPoolAddr: Address,
+        public tokenA: Address,
+        public tokenB: Address
+	) {
+		super()
+		this.swapPool = new web3.eth.Contract(SwapABI, swapPoolAddr) as unknown as ISymmetricSwap
+	}
+
+	protected async _init() {
+        const swappaPairAddress = await selectAddress(this.web3, {mainnet: pairSymmetricSwapAddress})
+		return {
+			pairKey: this.swapPoolAddr,
+			tokenA: this.tokenA,
+            tokenB: this.tokenA,
+            swappaPairAddress
+        }
+	}
+
+	public async refresh() {
+		this.paused = await this.swapPool.methods.paused().call()
+	}
+
+	public outputAmount(inputToken: Address, inputAmount: BigNumber): BigNumber {
+		if (this.paused || (inputToken !== this.tokenA && inputToken !== this.tokenB)) {
+			return ZERO
+		}
+		return inputAmount
+	}
+
+	protected swapExtraData() {
+		return this.swapPoolAddr
+	}
+
+	public snapshot(): PairSymmetricSwapSnapshot {
+		return {
+			paused: this.paused
+		}
+	}
+
+	public restore(snapshot: PairSymmetricSwapSnapshot): void {
+		this.paused = snapshot.paused
+	}
+}

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -5,6 +5,7 @@ import { SavingsCELOAddressMainnet } from "@terminal-fi/savingscelo"
 import { PairSavingsCELO } from "./pairs/savingscelo"
 import { PairStableSwap } from "./pairs/stableswap"
 import { PairOpenSumSwap } from "./pairs/opensumswap"
+import { PairSymmetricSwap } from "./pairs/symmetricswap"
 import { RegistryAave } from "./registries/aave"
 import { RegistryAaveV2 } from "./registries/aave-v2"
 import { RegistryMento } from "./registries/mento"
@@ -48,6 +49,8 @@ export const mainnetRegistryMobius =
 			new PairOpenSumSwap(web3, "0xb1a0BDe36341065cA916c9f5619aCA82A43659A3"), // wETH <-> wETHv2
 			new PairOpenSumSwap(web3, "0xd5ab1BA8b2Ec70752068d1d728e728eAd0E19CBA"), // wBTC <-> wBTCv2
 			new PairOpenSumSwap(web3, "0x70bfA1C8Ab4e42B9BE74f65941EFb6e5308148c7"), // USDC <-> USDCv2
+			// Symmetric V1 <-> V2 migration
+			new PairSymmetricSwap(web3, "0xF21150EC57c360dA61cE7900dbaFdE9884198026", "0x7c64aD5F9804458B8c9F93f7300c15D55956Ac2a", "0x8427bD503dd3169cCC9aFF7326c15258Bc305478")
 		])
 	}
 export const mainnetRegistrySavingsCELO =

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -45,6 +45,12 @@ export const mainnetRegistryMobius =
 			new PairStableSwap(web3, "0xFc9e2C63370D8deb3521922a7B2b60f4Cff7e75a"), // CELO <-> pCELOv2
 			new PairStableSwap(web3, "0x23C95678862a229fAC088bd9705622d78130bC3e"), // cEUR <-> pEURv2
 			new PairStableSwap(web3, "0x9F4AdBD0af281C69a582eB2E6fa2A594D4204CAe"), // cUSD <-> atUST
+		])
+	}
+export const mainnetRegistryMisc =
+	(kit: ContractKit) => {
+		const web3 = kit.web3 as unknown as Web3
+		return new RegistryStatic("misc", [
 			// Optics V1 <-> V2 migration
 			new PairOpenSumSwap(web3, "0xb1a0BDe36341065cA916c9f5619aCA82A43659A3"), // wETH <-> wETHv2
 			new PairOpenSumSwap(web3, "0xd5ab1BA8b2Ec70752068d1d728e728eAd0E19CBA"), // wBTC <-> wBTCv2
@@ -81,4 +87,5 @@ export const mainnetRegistriesWhitelist = (kit: ContractKit) => ([
 	// Direct conversion protocols:
 	mainnetRegistryMoola(kit),
 	mainnetRegistryMoolaV2(kit),
+	mainnetRegistryMisc(kit),
 ])

--- a/tools/deployed/mainnet.PairSymmetricSwap.addr.json
+++ b/tools/deployed/mainnet.PairSymmetricSwap.addr.json
@@ -1,0 +1,1 @@
+{"address":"0xf155e5c0103fA49eFC389212bA639B81559D1ed0"}


### PR DESCRIPTION
SYMM v1 to v2 can be swapped 1:1 no fee

Annoying thing is that its easiest to stuff this pair into the Mobius static pair definition vs try to put it into the Symmetric balancer registry. It's one of those one-off swap contracts like OpenSumSwap that's just to do token migrations.

Maybe I move the Optics migration pair out into another static registry just for these odds and ends 1:1 swap contracts


Pair deployed and running arbs:
[0xf155e5c0103fA49eFC389212bA639B81559D1ed0](https://explorer.celo.org/address/0xf155e5c0103fA49eFC389212bA639B81559D1ed0/contracts)

Migration swap contract:
[0xF21150EC57c360dA61cE7900dbaFdE9884198026](https://explorer.celo.org/address/0xF21150EC57c360dA61cE7900dbaFdE9884198026/token-transfers)



