### PR TITLE
Uniswap registry fetch using all pairs by default

### DIFF
--- a/src/registries/uniswapv2.ts
+++ b/src/registries/uniswapv2.ts
@@ -26,7 +26,7 @@ export class RegistryUniswapV2 extends Registry {
 
 	findPairs = async (tokenWhitelist: Address[]): Promise<Pair[]> =>  {
 		let pairsFetched
-		if (!this.opts?.fetchUsingAllPairs) {
+		if (this.opts?.fetchUsingAllPairs === false) {
 			const pairsToFetch: {tokenA: Address, tokenB: Address}[] = []
 			for (let i = 0; i < tokenWhitelist.length - 1; i += 1) {
 				for (let j = i + 1; j < tokenWhitelist.length; j += 1) {


### PR DESCRIPTION
Uniswap registry was using pairwise combination to fetch pairs by default:
`if (!this.opts?.fetchUsingAllPairs)`, `fetchUsingAllPairs === undefined` and negated become true

Given the number of tokens in the default token whitelist is pretty large now, this causes over 2k calls into the factory.

The actual number of pairs created by the factories are a lot smaller:
```
ubeswap nPairs 548
sushiswap nPairs 146
celodex nPairs 28
```
We can save the calls if we default `fetchUsingAllPairs` to `true`