### PR TITLE
Get rid of repeated web3.eth.getChainId() calls

### DIFF
--- a/src/pair.ts
+++ b/src/pair.ts
@@ -1,4 +1,4 @@
-import BigNumber from "bignumber.js";
+import BigNumber from "bignumber.js"
 
 export type Address = string
 
@@ -17,21 +17,23 @@ export abstract class Pair {
 	public pairKey: string | null = null;
 	public tokenA: Address = "";
 	public tokenB: Address = "";
-	protected swappaPairAddress: Address = "";
+	private swappaPairAddress: Address = "";
+
+	constructor(swappaPairAddress: Address) {
+		this.swappaPairAddress = swappaPairAddress
+	}
 
 	public async init(): Promise<void> {
 		const r = await this._init()
 		this.pairKey = r.pairKey
 		this.tokenA = r.tokenA
 		this.tokenB = r.tokenB
-		this.swappaPairAddress = r.swappaPairAddress
 		return this.refresh()
 	}
 	protected abstract _init(): Promise<{
 		pairKey: string | null,
 		tokenA: Address,
 		tokenB: Address,
-		swappaPairAddress: Address,
 	}>;
 	public abstract refresh(): Promise<void>;
 	public swapData(inputToken: Address): SwapData {
@@ -94,7 +96,7 @@ export abstract class PairXYeqK extends Pair {
 		return {
 			fee: this.fee.toFixed(),
 			bucketA: this.bucketA.toFixed(),
-			bucketB: this.bucketB.toFixed()
+			bucketB: this.bucketB.toFixed(),
 		}
 	}
 

--- a/src/pairs/atoken-v2.ts
+++ b/src/pairs/atoken-v2.ts
@@ -13,11 +13,12 @@ export class PairATokenV2 extends Pair {
 	private pool: ILendingPoolV2
 
 	constructor(
+		chainId: number,
 		private web3: Web3,
 		private poolAddr: Address,
 		private reserve: Address,
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairATokenV2Address}))
 		this.pool = new this.web3.eth.Contract(ILendingPoolV2ABI, this.poolAddr) as unknown as ILendingPoolV2
 	}
 
@@ -28,7 +29,6 @@ export class PairATokenV2 extends Pair {
 		return {
 			pairKey: null,
 			tokenA, tokenB,
-			swappaPairAddress: await selectAddress(this.web3, {mainnet: pairATokenV2Address})
 		}
 	}
 	public async refresh(): Promise<void> {}

--- a/src/pairs/atoken.ts
+++ b/src/pairs/atoken.ts
@@ -16,11 +16,12 @@ export class PairAToken extends Pair {
 	private provider: ILendingPoolAddressesProvider
 
 	constructor(
+		chainId: number,
 		private kit: ContractKit,
 		private providerAddr: Address,
 		private reserve: Address,
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairATokenAddress}))
 		this.provider = new kit.web3.eth.Contract(
 			LendingPoolAddressProviderABI, providerAddr) as unknown as ILendingPoolAddressesProvider
 	}
@@ -35,7 +36,6 @@ export class PairAToken extends Pair {
 		return {
 			pairKey: null,
 			tokenA, tokenB,
-			swappaPairAddress: await selectAddress(this.kit.web3 as unknown as Web3, {mainnet: pairATokenAddress})
 		}
 	}
 	public async refresh(): Promise<void> {}

--- a/src/pairs/bpool.ts
+++ b/src/pairs/bpool.ts
@@ -25,12 +25,13 @@ export class PairBPool extends Pair {
 	private balanceB: BigNumber = ZERO
 
 	constructor(
-		private web3: Web3,
+		chainId: number,
+		web3: Web3,
 		private poolAddr: Address,
 		public tokenA: Address,
-		public tokenB: Address
+		public tokenB: Address,
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairBPoolAddress}))
 		this.bPool = new web3.eth.Contract(BPoolABI, poolAddr) as unknown as IbPool
 	}
 
@@ -38,14 +39,11 @@ export class PairBPool extends Pair {
 		const [
 			swapFee,
 			weightA,
-			weightB,
-			swappaPairAddress
+			weightB
 		] = await Promise.all([
 			this.bPool.methods.getSwapFee().call(),
 			this.bPool.methods.getDenormalizedWeight(this.tokenA).call(),
 			this.bPool.methods.getDenormalizedWeight(this.tokenB).call(),
-			// TODO: change this after merge to the actual deployed PairBPool swap address
-			selectAddress(this.web3, {mainnet: pairBPoolAddress})
 		])
 		this.swapFee = new BigNumber(swapFee).div(BONE)
 		this.weightA = new BigNumber(weightA)
@@ -55,7 +53,6 @@ export class PairBPool extends Pair {
 			pairKey: this.poolAddr,
 			tokenA: this.tokenA,
 			tokenB: this.tokenB,
-			swappaPairAddress
 		}
 	}
 

--- a/src/pairs/mento.ts
+++ b/src/pairs/mento.ts
@@ -17,10 +17,11 @@ export class PairMento extends PairXYeqK {
 	private sortedOracles?: SortedOraclesWrapper
 
 	constructor(
+		chainId: number,
 		private kit: ContractKit,
 		private stableToken: StableToken,
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairMentoAddress}))
 	}
 
 	protected async _init() {
@@ -33,7 +34,6 @@ export class PairMento extends PairXYeqK {
 			pairKey: this.exchange.address,
 			tokenA: celo.address,
 			tokenB: cSTB.address,
-			swappaPairAddress: await selectAddress(this.kit.web3 as unknown as Web3, {mainnet: pairMentoAddress})
 		}
 	}
 

--- a/src/pairs/opensumswap.ts
+++ b/src/pairs/opensumswap.ts
@@ -21,10 +21,11 @@ export class PairOpenSumSwap extends Pair {
 	private balances: BigNumber[] = []
 
 	constructor(
-		private web3: Web3,
+		chainId: number,
+		web3: Web3,
 		private swapPoolAddr: Address,
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairOpenSumSwapAddress}))
 		this.swapPool = new web3.eth.Contract(SwapABI, swapPoolAddr) as unknown as IOpenSumSwap
 	}
 
@@ -32,15 +33,14 @@ export class PairOpenSumSwap extends Pair {
 		const [
 			tokenA,
 			tokenB,
-			swappaPairAddress,
 		] = await Promise.all([
 			this.swapPool.methods.getToken(0).call(),
 			this.swapPool.methods.getToken(1).call(),
-			selectAddress(this.web3, {mainnet: pairOpenSumSwapAddress}),
 		])
 		return {
 			pairKey: this.swapPoolAddr,
-			tokenA,  tokenB, swappaPairAddress}
+			tokenA, tokenB,
+		}
 	}
 
 	public async refresh() {

--- a/src/pairs/savingscelo.ts
+++ b/src/pairs/savingscelo.ts
@@ -19,10 +19,11 @@ export class PairSavingsCELO extends Pair {
 	private totalSupplies?: {celoTotal: BigNumber, savingsTotal: BigNumber}
 
 	constructor(
+		chainId: number,
 		private kit: ContractKit,
 		savingsCELOAddr: Address,
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairSavingsCELOAddress}))
 		this.savingsKit = new SavingsKit(kit, savingsCELOAddr)
 	}
 
@@ -33,7 +34,6 @@ export class PairSavingsCELO extends Pair {
 		return {
 			pairKey: null,
 			tokenA, tokenB,
-			swappaPairAddress: await selectAddress(this.kit.web3 as unknown as Web3, {mainnet: pairSavingsCELOAddress})
 		}
 	}
 	public async refresh(): Promise<void> {

--- a/src/pairs/stableswap.ts
+++ b/src/pairs/stableswap.ts
@@ -30,10 +30,11 @@ export class PairStableSwap extends Pair {
 	static readonly A_PRECISION = 100
 
 	constructor(
+		chainId: number,
 		private web3: Web3,
 		private swapPoolAddr: Address,
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairStableSwapAddress}))
 		this.swapPool = new web3.eth.Contract(SwapABI, swapPoolAddr) as unknown as ISwap
 	}
 
@@ -41,11 +42,9 @@ export class PairStableSwap extends Pair {
 		const [
 			tokenA,
 			tokenB,
-			swappaPairAddress,
 		] = await Promise.all([
 			this.swapPool.methods.getToken(0).call(),
 			this.swapPool.methods.getToken(1).call(),
-			selectAddress(this.web3, {mainnet: pairStableSwapAddress}),
 		])
 		const erc20A = new this.web3.eth.Contract(Erc20ABI, tokenA) as unknown as Erc20
 		const erc20B = new this.web3.eth.Contract(Erc20ABI, tokenB) as unknown as Erc20
@@ -62,7 +61,8 @@ export class PairStableSwap extends Pair {
 		]
 		return {
 			pairKey: this.swapPoolAddr,
-			tokenA,  tokenB, swappaPairAddress}
+			tokenA, tokenB,
+		}
 	}
 
 	public async refresh() {

--- a/src/pairs/symmetricswap.ts
+++ b/src/pairs/symmetricswap.ts
@@ -26,12 +26,13 @@ export class PairSymmetricSwap extends Pair {
 	private balanceB: BigNumber = ZERO
 
 	constructor(
-		private web3: Web3,
+		chainId: number,
+		web3: Web3,
 		private swapPoolAddr: Address,
 		public tokenA: Address,
-		public tokenB: Address
+		public tokenB: Address,
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairSymmetricSwapAddress}))
 		// Unfortunately SymmetricSwap contract doesn't expose token addresses that it stores,
 		// thus they have to be hardcoded in the constructor and can't be fetched from swapPool
 		// directly.
@@ -41,12 +42,10 @@ export class PairSymmetricSwap extends Pair {
 	}
 
 	protected async _init() {
-		const swappaPairAddress = await selectAddress(this.web3, {mainnet: pairSymmetricSwapAddress})
 		return {
 			pairKey: this.swapPoolAddr,
 			tokenA: this.tokenA,
 			tokenB: this.tokenB,
-			swappaPairAddress
 		}
 	}
 

--- a/src/pairs/uniswapv2.ts
+++ b/src/pairs/uniswapv2.ts
@@ -13,11 +13,12 @@ export class PairUniswapV2 extends PairXYeqK {
 	private feeKData: string
 
 	constructor(
+		chainId: number,
 		private web3: Web3,
 		private pairAddr: Address,
 		private fixedFee: BigNumber = new BigNumber(0.997),
 	) {
-		super()
+		super(selectAddress(chainId, {mainnet: pairUniswapV2Address}))
 		this.pair = new this.web3.eth.Contract(PairABI, pairAddr) as unknown as IUniswapV2Pair
 		const feeKInv = new BigNumber(1000).minus(this.fixedFee.multipliedBy(1000))
 		if (!feeKInv.isInteger() || !feeKInv.gt(0) || !feeKInv.lt(100)) {
@@ -27,14 +28,13 @@ export class PairUniswapV2 extends PairXYeqK {
 	}
 
 	protected async _init() {
-		const [tokenA, tokenB, swappaPairAddress] = await Promise.all([
+		const [tokenA, tokenB] = await Promise.all([
 			this.pair.methods.token0().call(),
 			this.pair.methods.token1().call(),
-			selectAddress(this.web3, {mainnet: pairUniswapV2Address}),
 		])
 		return {
 			pairKey: this.pairAddr,
-			tokenA, tokenB, swappaPairAddress,
+			tokenA, tokenB,
 		}
 	}
 

--- a/src/registries/aave-v2.ts
+++ b/src/registries/aave-v2.ts
@@ -17,11 +17,12 @@ export class RegistryAaveV2 extends Registry {
 	}
 
 	findPairs = async (tokenWhitelist: Address[]) => {
+		const chainId = await this.web3.eth.getChainId()
 		const poolAddr: string = await this.provider.methods.getLendingPool().call()
 		const lendingPool: ILendingPoolV2 = new this.web3.eth.Contract(ILendingPoolV2ABI, poolAddr) as unknown as ILendingPoolV2
 		const reserves: Address[] = await lendingPool.methods.getReservesList().call()
 		const reservesMatched = reserves.filter((r) => tokenWhitelist.indexOf(r) >= 0)
-		const pairs = reservesMatched.map((r) => (new PairATokenV2(this.web3, poolAddr, r)))
+		const pairs = reservesMatched.map((r) => (new PairATokenV2(chainId, this.web3, poolAddr, r)))
 		return initPairsAndFilterByWhitelist(pairs, tokenWhitelist)
 	}
 }

--- a/src/registries/aave.ts
+++ b/src/registries/aave.ts
@@ -17,6 +17,7 @@ export class RegistryAave extends Registry {
 	}
 
 	findPairs = async (tokenWhitelist: Address[]) => {
+		const chainId = await this.kit.web3.eth.getChainId()
 		const lendingPoolAddr = await this.lendingPoolAddrProvider.methods.getLendingPool().call()
 		const lendingPool = new this.kit.web3.eth.Contract(LendingPoolABI, lendingPoolAddr) as unknown as ILendingPool
 		const reserves = await lendingPool.methods.getReserves().call()
@@ -25,7 +26,7 @@ export class RegistryAave extends Registry {
 			...reserves.filter((r) => tokenWhitelist.indexOf(r) >= 0),
 		]
 		const pairs = reservesMatched.map((r) => (
-			new PairAToken(this.kit, this.lendingPoolAddrProvider.options.address, r)))
+			new PairAToken(chainId, this.kit, this.lendingPoolAddrProvider.options.address, r)))
 		return initPairsAndFilterByWhitelist(pairs, tokenWhitelist)
 	}
 }

--- a/src/registries/balancer.ts
+++ b/src/registries/balancer.ts
@@ -20,6 +20,7 @@ export class RegistryBalancer extends Registry {
 	}
 
 	findPairs = async (tokenWhitelist: Address[]): Promise<Pair[]> =>  {
+		const chainId = await this.web3.eth.getChainId()
 		const pairsToFetch: {tokenA: Address, tokenB: Address}[] = []
 		for (let i = 0; i < tokenWhitelist.length - 1; i += 1) {
 			for (let j = i + 1; j < tokenWhitelist.length; j += 1) {
@@ -37,7 +38,7 @@ export class RegistryBalancer extends Registry {
 				}
 
 				for (const poolAddr of pools) {
-					const pool = new PairBPool(this.web3, poolAddr, toFetch.tokenA, toFetch.tokenB)
+					const pool = new PairBPool(chainId, this.web3, poolAddr, toFetch.tokenA, toFetch.tokenB)
 					// bpool can be used for each input & output combination
 					let key
 					if (toFetch.tokenA.toLowerCase().localeCompare(toFetch.tokenB.toLowerCase()) > 0) {

--- a/src/registries/mento.ts
+++ b/src/registries/mento.ts
@@ -21,7 +21,8 @@ export class RegistryMento extends Registry{
 					wrapper: wrapper,
 				}))
 			})
-		const pairs = cSTBs.map((cSTB) => (new PairMento(this.kit, cSTB.name)))
+		const chainId = await this.kit.web3.eth.getChainId()
+		const pairs = cSTBs.map((cSTB) => (new PairMento(chainId, this.kit, cSTB.name)))
 		return initPairsAndFilterByWhitelist(pairs, tokenWhitelist)
 	}
 }

--- a/src/registries/static.ts
+++ b/src/registries/static.ts
@@ -3,11 +3,11 @@ import { Registry } from "../registry"
 import { initPairsAndFilterByWhitelist } from "../utils"
 
 export class RegistryStatic extends Registry{
-	constructor(name: string, private pairsAll: Pair[]) {
+	constructor(name: string, private pairsAll: Promise<Pair[]>) {
 		super(name)
 	}
 
 	findPairs = async (tokenWhitelist: Address[]) => {
-		return initPairsAndFilterByWhitelist(this.pairsAll, tokenWhitelist)
+		return initPairsAndFilterByWhitelist(await this.pairsAll, tokenWhitelist)
 	}
 }

--- a/src/registries/uniswapv2.ts
+++ b/src/registries/uniswapv2.ts
@@ -25,6 +25,7 @@ export class RegistryUniswapV2 extends Registry {
 	}
 
 	findPairs = async (tokenWhitelist: Address[]): Promise<Pair[]> =>  {
+		const chainId = await this.web3.eth.getChainId()
 		let pairsFetched
 		if (!this.opts?.fetchUsingAllPairs) {
 			const pairsToFetch: {tokenA: Address, tokenB: Address}[] = []
@@ -41,7 +42,7 @@ export class RegistryUniswapV2 extends Registry {
 					if (pairAddr === "0x0000000000000000000000000000000000000000") {
 						return null
 					}
-					return new PairUniswapV2(this.web3, pairAddr, this.opts?.fixedFee)
+					return new PairUniswapV2(chainId, this.web3, pairAddr, this.opts?.fixedFee)
 				})
 		} else {
 			const nPairs = Number.parseInt(await this.factory.methods.allPairsLength().call())
@@ -50,7 +51,7 @@ export class RegistryUniswapV2 extends Registry {
 				[...Array(nPairs).keys()],
 				async (idx) => {
 					const pairAddr = await this.factory.methods.allPairs(idx).call()
-					return new PairUniswapV2(this.web3, pairAddr, this.opts?.fixedFee)
+					return new PairUniswapV2(chainId, this.web3, pairAddr, this.opts?.fixedFee)
 				})
 		}
 		const pairs = pairsFetched.filter((p) => p !== null) as Pair[]

--- a/src/registry-cfg.ts
+++ b/src/registry-cfg.ts
@@ -22,48 +22,48 @@ export const mainnetRegistrySushiswap =
 export const mainnetRegistryMobius =
 	(kit: ContractKit) => {
 		const web3 = kit.web3 as unknown as Web3
-		return new RegistryStatic("mobius", [
+		return new RegistryStatic("mobius", web3.eth.getChainId().then(chainId => [
 			// Source: https://github.com/mobiusAMM/mobiusV1
-			new PairStableSwap(web3, "0x0ff04189Ef135b6541E56f7C638489De92E9c778"), // cUSD <-> bUSDC
-			new PairStableSwap(web3, "0xdBF27fD2a702Cc02ac7aCF0aea376db780D53247"), // cUSD <-> cUSDT
-			new PairStableSwap(web3, "0xE0F2cc70E52f05eDb383313393d88Df2937DA55a"), // cETH <-> WETH
-			new PairStableSwap(web3, "0x19260b9b573569dDB105780176547875fE9fedA3"), //  BTC <-> WBTC
-			new PairStableSwap(web3, "0xA5037661989789d0310aC2B796fa78F1B01F195D"), // cUSD <-> USDC
-			new PairStableSwap(web3, "0x2080AAa167e2225e1FC9923250bA60E19a180Fb2"), // cUSD <-> pUSDC
-			new PairStableSwap(web3, "0x63C1914bf00A9b395A2bF89aaDa55A5615A3656e"), // cUSD <-> asUSDC
-			new PairStableSwap(web3, "0x382Ed834c6b7dBD10E4798B08889eaEd1455E820"), // cEUR <-> pEUR
-			new PairStableSwap(web3, "0x413FfCc28e6cDDE7e93625Ef4742810fE9738578"), // CELO <-> pCELO
-			new PairStableSwap(web3, "0x02Db089fb09Fda92e05e92aFcd41D9AAfE9C7C7C"), // cUSD <-> pUSD
-			new PairStableSwap(web3, "0x0986B42F5f9C42FeEef66fC23eba9ea1164C916D"), // cUSD <-> aaUSDC
+			new PairStableSwap(chainId, web3, "0x0ff04189Ef135b6541E56f7C638489De92E9c778"), // cUSD <-> bUSDC
+			new PairStableSwap(chainId, web3, "0xdBF27fD2a702Cc02ac7aCF0aea376db780D53247"), // cUSD <-> cUSDT
+			new PairStableSwap(chainId, web3, "0xE0F2cc70E52f05eDb383313393d88Df2937DA55a"), // cETH <-> WETH
+			new PairStableSwap(chainId, web3, "0x19260b9b573569dDB105780176547875fE9fedA3"), //  BTC <-> WBTC
+			new PairStableSwap(chainId, web3, "0xA5037661989789d0310aC2B796fa78F1B01F195D"), // cUSD <-> USDC
+			new PairStableSwap(chainId, web3, "0x2080AAa167e2225e1FC9923250bA60E19a180Fb2"), // cUSD <-> pUSDC
+			new PairStableSwap(chainId, web3, "0x63C1914bf00A9b395A2bF89aaDa55A5615A3656e"), // cUSD <-> asUSDC
+			new PairStableSwap(chainId, web3, "0x382Ed834c6b7dBD10E4798B08889eaEd1455E820"), // cEUR <-> pEUR
+			new PairStableSwap(chainId, web3, "0x413FfCc28e6cDDE7e93625Ef4742810fE9738578"), // CELO <-> pCELO
+			new PairStableSwap(chainId, web3, "0x02Db089fb09Fda92e05e92aFcd41D9AAfE9C7C7C"), // cUSD <-> pUSD
+			new PairStableSwap(chainId, web3, "0x0986B42F5f9C42FeEef66fC23eba9ea1164C916D"), // cUSD <-> aaUSDC
 			// Opticsv2: https://github.com/mobiusAMM/mobius-interface/blob/main/src/constants/StablePools.ts
-			new PairStableSwap(web3, "0x9906589Ea8fd27504974b7e8201DF5bBdE986b03"), // cUSD <-> USDCv2
-			new PairStableSwap(web3, "0xF3f65dFe0c8c8f2986da0FEc159ABE6fd4E700B4"), // cUSD <-> DAIv2
-			new PairStableSwap(web3, "0x74ef28D635c6C5800DD3Cd62d4c4f8752DaACB09"), // cETH <-> WETHv2
-			new PairStableSwap(web3, "0xaEFc4e8cF655a182E8346B24c8AbcE45616eE0d2"), // cBTC <-> WBTCv2
-			new PairStableSwap(web3, "0xcCe0d62Ce14FB3e4363Eb92Db37Ff3630836c252"), // cUSD <-> pUSDCv2
-			new PairStableSwap(web3, "0xa2F0E57d4cEAcF025E81C76f28b9Ad6E9Fbe8735"), // cUSD <-> pUSDv2
-			new PairStableSwap(web3, "0xFc9e2C63370D8deb3521922a7B2b60f4Cff7e75a"), // CELO <-> pCELOv2
-			new PairStableSwap(web3, "0x23C95678862a229fAC088bd9705622d78130bC3e"), // cEUR <-> pEURv2
-			new PairStableSwap(web3, "0x9F4AdBD0af281C69a582eB2E6fa2A594D4204CAe"), // cUSD <-> atUST
-		])
+			new PairStableSwap(chainId, web3, "0x9906589Ea8fd27504974b7e8201DF5bBdE986b03"), // cUSD <-> USDCv2
+			new PairStableSwap(chainId, web3, "0xF3f65dFe0c8c8f2986da0FEc159ABE6fd4E700B4"), // cUSD <-> DAIv2
+			new PairStableSwap(chainId, web3, "0x74ef28D635c6C5800DD3Cd62d4c4f8752DaACB09"), // cETH <-> WETHv2
+			new PairStableSwap(chainId, web3, "0xaEFc4e8cF655a182E8346B24c8AbcE45616eE0d2"), // cBTC <-> WBTCv2
+			new PairStableSwap(chainId, web3, "0xcCe0d62Ce14FB3e4363Eb92Db37Ff3630836c252"), // cUSD <-> pUSDCv2
+			new PairStableSwap(chainId, web3, "0xa2F0E57d4cEAcF025E81C76f28b9Ad6E9Fbe8735"), // cUSD <-> pUSDv2
+			new PairStableSwap(chainId, web3, "0xFc9e2C63370D8deb3521922a7B2b60f4Cff7e75a"), // CELO <-> pCELOv2
+			new PairStableSwap(chainId, web3, "0x23C95678862a229fAC088bd9705622d78130bC3e"), // cEUR <-> pEURv2
+			new PairStableSwap(chainId, web3, "0x9F4AdBD0af281C69a582eB2E6fa2A594D4204CAe"), // cUSD <-> atUST
+		]))
 	}
 export const mainnetRegistryMisc =
 	(kit: ContractKit) => {
 		const web3 = kit.web3 as unknown as Web3
-		return new RegistryStatic("misc", [
+		return new RegistryStatic("misc", web3.eth.getChainId().then(chainId => [
 			// Optics V1 <-> V2 migration
-			new PairOpenSumSwap(web3, "0xb1a0BDe36341065cA916c9f5619aCA82A43659A3"), // wETH <-> wETHv2
-			new PairOpenSumSwap(web3, "0xd5ab1BA8b2Ec70752068d1d728e728eAd0E19CBA"), // wBTC <-> wBTCv2
-			new PairOpenSumSwap(web3, "0x70bfA1C8Ab4e42B9BE74f65941EFb6e5308148c7"), // USDC <-> USDCv2
+			new PairOpenSumSwap(chainId, web3, "0xb1a0BDe36341065cA916c9f5619aCA82A43659A3"), // wETH <-> wETHv2
+			new PairOpenSumSwap(chainId, web3, "0xd5ab1BA8b2Ec70752068d1d728e728eAd0E19CBA"), // wBTC <-> wBTCv2
+			new PairOpenSumSwap(chainId, web3, "0x70bfA1C8Ab4e42B9BE74f65941EFb6e5308148c7"), // USDC <-> USDCv2
 			// Symmetric V1 <-> V2 migration
-			new PairSymmetricSwap(web3,
+			new PairSymmetricSwap(chainId, web3,
 				"0xF21150EC57c360dA61cE7900dbaFdE9884198026", "0x7c64aD5F9804458B8c9F93f7300c15D55956Ac2a", "0x8427bD503dd3169cCC9aFF7326c15258Bc305478")
-		])
+		]))
 	}
 export const mainnetRegistrySavingsCELO =
-	(kit: ContractKit) => new RegistryStatic("savingscelo", [
-		new PairSavingsCELO(kit, SavingsCELOAddressMainnet),
-	])
+	(kit: ContractKit) => new RegistryStatic("savingscelo", web3.eth.getChainId().then(chainId => [
+		new PairSavingsCELO(chainId, kit, SavingsCELOAddressMainnet),
+	]))
 export const mainnetRegistryMoolaV2 =
 	(kit: ContractKit) => new RegistryAaveV2("moola-v2", kit.web3 as unknown as Web3, "0xD1088091A174d33412a968Fa34Cb67131188B332")
 export const mainnetRegistryCeloDex =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,12 +17,7 @@ interface AddressesByNetwork {
 	alfajores?: Address,
 }
 
-export const selectAddress = async (web3: Web3, addresses: AddressesByNetwork) => {
-	const chainId = await web3.eth.getChainId()
-	return selectAddressUsingChainId(chainId, addresses)
-}
-
-export const selectAddressUsingChainId = (chainId: number, addresses: AddressesByNetwork) => {
+export const selectAddress = (chainId: number, addresses: AddressesByNetwork) => {
 	switch (chainId) {
 	case 42220:
 		if (!addresses.mainnet) {


### PR DESCRIPTION
Every single pair was making a getChainID() call to load its network address inside `init()`.

This is unnecessary, lift it up to the registry level as part of `findPairs()` to retrieve the chain ID and pass into constructor of Pair.

Make initialization faster and more scalable for thousands of pairs.
This also makes it easier for me to bulk instantiate and refresh all pairs now that the swappa pair address is not part of `async init()`