### PR TITLE
Fix getOutputAmount for 1:1 swap contracts

### DIFF
--- a/contracts/swappa/PairOpenSumSwap.sol
+++ b/contracts/swappa/PairOpenSumSwap.sol
@@ -44,7 +44,9 @@ contract PairOpenSumSwap is ISwappaPairV1 {
 		uint amountIn,
 		bytes calldata data
 	) external view override returns (uint amountOut) {
-		// no fees are taken
-		return amountIn;
+		// no fees are taken if there's enough output token
+		if (ERC20(output).balanceOf(parseData(data)) >= amountIn) {
+			amountOut = amountIn;
+		}
 	}
 }

--- a/contracts/swappa/PairOpenSumSwap.sol
+++ b/contracts/swappa/PairOpenSumSwap.sol
@@ -44,8 +44,9 @@ contract PairOpenSumSwap is ISwappaPairV1 {
 		uint amountIn,
 		bytes calldata data
 	) external view override returns (uint amountOut) {
+		IOpenSumSwap pool = IOpenSumSwap(parseData(data));
 		// no fees are taken if there's enough output token
-		if (ERC20(output).balanceOf(parseData(data)) >= amountIn) {
+		if (!pool.paused() && ERC20(output).balanceOf(address(pool)) >= amountIn) {
 			amountOut = amountIn;
 		}
 	}

--- a/contracts/swappa/PairSymmetricSwap.sol
+++ b/contracts/swappa/PairSymmetricSwap.sol
@@ -42,7 +42,9 @@ contract PairSymmetricSwap is ISwappaPairV1 {
 		uint amountIn,
 		bytes calldata data
 	) external view override returns (uint amountOut) {
-		// no fees are taken
-		return amountIn;
+		// no fees are taken if there's enough output token
+		if (ERC20(output).balanceOf(parseData(data)) >= amountIn) {
+			amountOut = amountIn;
+		}
 	}
 }


### PR DESCRIPTION
Fix the 1:1 token swap contracts's `getOutputAmount` method to validate that there's enough out token available.

Deployed prototypes:
https://explorer.celo.org/address/0x98b4921c4CCc27686bF467DD38588067e9A1F44F/contracts
https://explorer.celo.org/address/0xb7ff44E0e8c7c04dB7493CD78820C745dE4C5cEf/contracts