### PR TITLE
Adding Curve support

### DIFF
--- a/contracts/interfaces/curve/ICurve.sol
+++ b/contracts/interfaces/curve/ICurve.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.8;
+
+interface ICurve {
+    function A() external view returns (uint256);
+
+    function A_precise() external view returns (uint256);
+
+    function fee() external view returns (uint256);
+
+    function coins(uint256 i) external view returns (address);
+
+    function balances(uint256 i) external view returns (uint256);
+
+    function exchange(
+        int128 i,
+        int128 j,
+        uint256 dx,
+        uint256 min_dy
+    ) external returns (uint256);
+
+    function get_dy(
+        int128 i,
+        int128 j,
+        uint256 dx
+    ) external view returns (uint256);
+
+    function get_virtual_price() external view returns (uint256);
+}

--- a/contracts/swappa/PairCurve.sol
+++ b/contracts/swappa/PairCurve.sol
@@ -66,19 +66,26 @@ contract PairCurve is ISwappaPairV1 {
 		return swapPool.get_dy(fromIdx, toIdx, amountIn);
 	}
 
-	function getInputOutputIdx(
-		ICurve swapPool,
-		address input,
-		address output
-	) private view returns (int128 fromIdx, int128 toIdx) {
-		uint8 idx;
-		// curve pool contain at most 4 coins
-		for (idx = 0; idx < 4; idx++) {
-			if (swapPool.coins(idx) == input) {
-				fromIdx = idx;
-			} else if (swapPool.coins(idx) == output) {
-				toIdx = idx;
-			}
-		}
-	}
+    function getInputOutputIdx(
+        ICurve swapPool,
+        address input,
+        address output
+    ) private view returns (int128 fromIdx, int128 toIdx) {
+        uint8 idx;
+        fromIdx = toIdx = -1;
+        // curve pool contain at most 4 coins
+        for (idx = 0; idx < 4; idx++) {
+            if (fromIdx != -1 && toIdx != -1) {
+                // found coin indices
+                break;
+            }
+            address coin = swapPool.coins(idx);
+            if (coin == input) {
+                fromIdx = idx;
+            }
+            if (coin == output) {
+                toIdx = idx;
+            }
+        }
+    }
 }

--- a/contracts/swappa/PairCurve.sol
+++ b/contracts/swappa/PairCurve.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.8;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "../interfaces/curve/ICurve.sol";
+import "./ISwappaPairV1.sol";
+
+contract PairCurve is ISwappaPairV1 {
+	using SafeMath for uint256;
+
+	function swap(
+		address input,
+		address output,
+		address to,
+		bytes calldata data
+	) external override {
+		address swapPoolAddr = parseData(data);
+		uint256 inputAmount = ERC20(input).balanceOf(address(this));
+		require(
+			ERC20(input).approve(swapPoolAddr, inputAmount),
+			"PairCurve: approve failed!"
+		);
+		ICurve swapPool = ICurve(swapPoolAddr);
+		(int128 fromIdx, int128 toIdx) = getInputOutputIdx(
+			swapPool,
+			input,
+			output
+		);
+		uint256 outputAmount = swapPool.exchange(
+			fromIdx,
+			toIdx,
+			inputAmount,
+			0
+		);
+		require(
+			ERC20(output).transfer(to, outputAmount),
+			"PairCurve: transfer failed!"
+		);
+	}
+
+	function parseData(bytes memory data)
+		private
+		pure
+		returns (address swapPoolAddr)
+	{
+		require(data.length == 20, "PairCurve: invalid data!");
+		assembly {
+			swapPoolAddr := mload(add(data, 20))
+		}
+	}
+
+	function getOutputAmount(
+		address input,
+		address output,
+		uint256 amountIn,
+		bytes calldata data
+	) external view override returns (uint256 amountOut) {
+		address swapPoolAddr = parseData(data);
+		ICurve swapPool = ICurve(swapPoolAddr);
+		(int128 fromIdx, int128 toIdx) = getInputOutputIdx(
+			swapPool,
+			input,
+			output
+		);
+		return swapPool.get_dy(fromIdx, toIdx, amountIn);
+	}
+
+	function getInputOutputIdx(
+		ICurve swapPool,
+		address input,
+		address output
+	) private view returns (int128 fromIdx, int128 toIdx) {
+		uint8 idx;
+		// curve pool contain at most 4 coins
+		for (idx = 0; idx < 4; idx++) {
+			if (swapPool.coins(idx) == input) {
+				fromIdx = idx;
+			} else if (swapPool.coins(idx) == output) {
+				toIdx = idx;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Contracts to support curve 3/4-pools
Curve interface created from ABI of https://blockscout.com/xdai/mainnet/address/0x7f90122BF0700F9E7e1F688fe926940E8839F353/contracts

PairCurve deployed at
https://blockscout.com/xdai/mainnet/address/0x404CF071C7Df717aa8367f86546d9268B652D82d/contracts

Once i'm confident of the typescript logic correctness, I'll open a PR for the other portion. The existing stableswap math can be refactored a little to be re-used between the PairCurve and PairStableSwap