### PR TITLE
express uniswap v2 fee in bips

### DIFF
--- a/contracts/swappa/PairUniswapV2.sol
+++ b/contracts/swappa/PairUniswapV2.sol
@@ -33,10 +33,11 @@ contract PairUniswapV2 is ISwappaPairV1 {
 
 	function parseData(bytes memory data) private pure returns (address pairAddr, uint fee) {
 		require(data.length == 21, "PairUniswapV2: invalid data!");
-		fee = uint(1000).sub(uint8(data[20]));
-    assembly {
-      pairAddr := mload(add(data, 20))
-    }
+		// fee in bips
+		fee = uint(10000).sub(uint8(data[20]));
+		assembly {
+		pairAddr := mload(add(data, 20))
+		}
 	}
 
 	function getOutputAmount(
@@ -55,7 +56,7 @@ contract PairUniswapV2 is ISwappaPairV1 {
 	function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut, uint feeK) internal pure returns (uint amountOut) {
 		uint amountInWithFee = amountIn.mul(feeK);
 		uint numerator = amountInWithFee.mul(reserveOut);
-		uint denominator = reserveIn.mul(1000).add(amountInWithFee);
+		uint denominator = reserveIn.mul(10000).add(amountInWithFee);
 		amountOut = numerator / denominator;
   	}
 

--- a/src/pairs/uniswapv2.ts
+++ b/src/pairs/uniswapv2.ts
@@ -18,10 +18,11 @@ export class PairUniswapV2 extends PairXYeqK {
 		private pairAddr: Address,
 		private fixedFee: BigNumber = new BigNumber(0.997),
 	) {
-		super(selectAddress(chainId, {mainnet: pairUniswapV2Address}))
+		super(selectAddress(chainId, { mainnet: pairUniswapV2Address }))
 		this.pair = new this.web3.eth.Contract(PairABI, pairAddr) as unknown as IUniswapV2Pair
-		const feeKInv = new BigNumber(1000).minus(this.fixedFee.multipliedBy(1000))
-		if (!feeKInv.isInteger() || !feeKInv.gt(0) || !feeKInv.lt(100)) {
+		const feeKInv = new BigNumber(10000).minus(this.fixedFee.multipliedBy(10000))
+		if (!feeKInv.isInteger() || !feeKInv.gt(0) || !feeKInv.lt(256)) {
+			// feeKInv must fit into uint8
 			throw new Error(`Invalid fixedFee: ${this.fixedFee}!`)
 		}
 		this.feeKData = feeKInv.toString(16).padStart(2, "0")


### PR DESCRIPTION
make it possible to declare fee as `0.9975` to represent a 25bps fee
encode the feeK as bips instead 10s of bips